### PR TITLE
adds supports for filtering on bytes ID columns

### DIFF
--- a/query-service-impl/build.gradle.kts
+++ b/query-service-impl/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
   }
   implementation("org.slf4j:slf4j-api:1.7.30")
   implementation("com.typesafe:config:1.3.2")
+  implementation("commons-codec:commons-codec:1.13")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.3")
 
   testImplementation(project(":query-service-api"))

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/Params.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/Params.java
@@ -15,18 +15,21 @@ public class Params {
   private Map<Integer, String> stringParams;
   private Map<Integer, Float> floatParams;
   private Map<Integer, Double> doubleParams;
+  private Map<Integer, String> bytesStringParams;
 
   private Params(
       Map<Integer, Integer> integerParams,
       Map<Integer, Long> longParams,
       Map<Integer, String> stringParams,
       Map<Integer, Float> floatParams,
-      Map<Integer, Double> doubleParams) {
+      Map<Integer, Double> doubleParams,
+      Map<Integer, String> bytesStringParams) {
     this.integerParams = integerParams;
     this.longParams = longParams;
     this.stringParams = stringParams;
     this.floatParams = floatParams;
     this.doubleParams = doubleParams;
+    this.bytesStringParams = bytesStringParams;
   }
 
   public Map<Integer, Integer> getIntegerParams() {
@@ -49,17 +52,23 @@ public class Params {
     return doubleParams;
   }
 
+  public Map<Integer, String> getBytesStringParams() {
+    return bytesStringParams;
+  }
+
   public static Builder newBuilder() {
     return new Builder();
   }
 
   public static class Builder {
+
     private int nextIndex;
     private Map<Integer, Integer> integerParams;
     private Map<Integer, Long> longParams;
     private Map<Integer, String> stringParams;
     private Map<Integer, Float> floatParams;
     private Map<Integer, Double> doubleParams;
+    private Map<Integer, String> bytesStringParams;
 
     private Builder() {
       nextIndex = 0;
@@ -68,6 +77,7 @@ public class Params {
       stringParams = new HashMap<>();
       floatParams = new HashMap<>();
       doubleParams = new HashMap<>();
+      bytesStringParams = new HashMap<>();
     }
 
     public Builder addIntegerParam(int paramValue) {
@@ -95,8 +105,14 @@ public class Params {
       return this;
     }
 
+    public Builder addBytesStringParam(String paramValue) {
+      bytesStringParams.put(nextIndex++, paramValue);
+      return this;
+    }
+
     public Params build() {
-      return new Params(integerParams, longParams, stringParams, floatParams, doubleParams);
+      return new Params(integerParams, longParams, stringParams, floatParams, doubleParams,
+          bytesStringParams);
     }
   }
 }

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/PinotClientFactory.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/PinotClientFactory.java
@@ -21,7 +21,8 @@ public class PinotClientFactory {
 
   private final ConcurrentHashMap<String, PinotClient> clientMap = new ConcurrentHashMap<>();
 
-  private PinotClientFactory() {}
+  private PinotClientFactory() {
+  }
 
   // Create a Pinot Client.
   public static PinotClient createPinotClient(String pinotCluster, String pathType, String path) {
@@ -52,6 +53,7 @@ public class PinotClientFactory {
   }
 
   public static class PinotClient {
+
     private static final String SQL_FORMAT = "sql";
 
     private final Connection connection;
@@ -95,6 +97,7 @@ public class PinotClientFactory {
       params.getLongParams().forEach(preparedStatement::setLong);
       params.getDoubleParams().forEach(preparedStatement::setDouble);
       params.getFloatParams().forEach(preparedStatement::setFloat);
+      params.getBytesStringParams().forEach(preparedStatement::setString);
       return preparedStatement;
     }
   }

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
@@ -30,396 +30,395 @@ import org.slf4j.LoggerFactory;
  */
 class QueryRequestToPinotSQLConverter {
 
-  private static final Logger LOG = LoggerFactory.getLogger(QueryRequestToPinotSQLConverter.class);
+    private static final Logger LOG = LoggerFactory.getLogger(QueryRequestToPinotSQLConverter.class);
 
-  private static final String QUESTION_MARK = "?";
-  private static final String REGEX_OPERATOR = "REGEXP_LIKE";
-  private static final String MAP_VALUE = "mapValue";
-  private static final int MAP_KEY_INDEX = 0;
-  private static final int MAP_VALUE_INDEX = 1;
+    private static final String QUESTION_MARK = "?";
+    private static final String REGEX_OPERATOR = "REGEXP_LIKE";
+    private static final String MAP_VALUE = "mapValue";
+    private static final int MAP_KEY_INDEX = 0;
+    private static final int MAP_VALUE_INDEX = 1;
 
-  private ViewDefinition viewDefinition;
-  private Joiner joiner = Joiner.on(", ").skipNulls();
+    private ViewDefinition viewDefinition;
+    private Joiner joiner = Joiner.on(", ").skipNulls();
 
-  QueryRequestToPinotSQLConverter(ViewDefinition viewDefinition) {
-    this.viewDefinition = viewDefinition;
-  }
-
-  Entry<String, Params> toSQL(
-      QueryContext queryContext, QueryRequest request, LinkedHashSet<Expression> allSelections) {
-    Params.Builder paramsBuilder = Params.newBuilder();
-    StringBuilder pqlBuilder = new StringBuilder("Select ");
-    String delim = "";
-
-    // Set the DISTINCT keyword if the request has set distinctSelections.
-    if (request.getDistinctSelections()) {
-      pqlBuilder.append("DISTINCT ");
+    QueryRequestToPinotSQLConverter(ViewDefinition viewDefinition) {
+        this.viewDefinition = viewDefinition;
     }
 
-    // allSelections contain all the various expressions in QueryRequest that we want selections on.
-    // Group bys, selections and aggregations in that order. See RequestAnalyzer#analyze() to see
-    // how it is created.
-    for (Expression expr : allSelections) {
-      pqlBuilder.append(delim);
-      pqlBuilder.append(convertExpression2String(expr, paramsBuilder));
-      delim = ", ";
-    }
-
-    pqlBuilder.append(" FROM ").append(viewDefinition.getViewName());
-
-    // Add the tenantId filter
-    pqlBuilder.append(" WHERE ").append(viewDefinition.getTenantIdColumn()).append(" = ?");
-    paramsBuilder.addStringParam(queryContext.getTenantId());
-
-    if (request.hasFilter()) {
-      pqlBuilder.append(" AND ");
-      String filterClause = convertFilter2String(request.getFilter(), paramsBuilder);
-      pqlBuilder.append(filterClause);
-    }
-
-    if (request.getGroupByCount() > 0) {
-      pqlBuilder.append(" GROUP BY ");
-      delim = "";
-      for (Expression groupByExpression : request.getGroupByList()) {
-        pqlBuilder.append(delim);
-        pqlBuilder.append(convertExpression2String(groupByExpression, paramsBuilder));
-        delim = ", ";
-      }
-    }
-    if (!request.getOrderByList().isEmpty()) {
-      pqlBuilder.append(" ORDER BY ");
-      delim = "";
-      for (OrderByExpression orderByExpression : request.getOrderByList()) {
-        pqlBuilder.append(delim);
-        String orderBy = convertExpression2String(orderByExpression.getExpression(), paramsBuilder);
-        pqlBuilder.append(orderBy);
-        if (SortOrder.DESC.equals(orderByExpression.getOrder())) {
-          pqlBuilder.append(" desc ");
-        }
-        delim = ", ";
-      }
-    }
-    if (request.getLimit() > 0) {
-      if (request.getOffset() > 0) {
-        pqlBuilder
-            .append(" limit ")
-            .append(request.getOffset())
-            .append(", ")
-            .append(request.getLimit());
-      } else {
-        pqlBuilder.append(" limit ").append(request.getLimit());
-      }
-    }
-
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("Converted QueryRequest to Pinot SQL: {}", pqlBuilder);
-    }
-    return new SimpleEntry<>(pqlBuilder.toString(), paramsBuilder.build());
-  }
-
-  private String convertFilter2String(Filter filter, Params.Builder paramsBuilder) {
-    StringBuilder builder = new StringBuilder();
-    String operator = convertOperator2String(filter.getOperator());
-    if (filter.getChildFilterCount() > 0) {
-      String delim = "";
-      builder.append("( ");
-      for (Filter childFilter : filter.getChildFilterList()) {
-        builder.append(delim);
-        builder.append(convertFilter2String(childFilter, paramsBuilder));
-        builder.append(" ");
-        delim = operator + " ";
-      }
-      builder.append(")");
-    } else {
-      switch (filter.getOperator()) {
-        case LIKE:
-          // The like operation in PQL looks like `regexp_like(lhs, rhs)`
-          Expression rhs = handleValueConversionForLiteralExpression(filter.getLhs(), filter.getRhs());
-          builder.append(operator);
-          builder.append("(");
-          builder.append(convertExpression2String(filter.getLhs(), paramsBuilder));
-          builder.append(",");
-          builder.append(convertExpression2String(rhs, paramsBuilder));
-          builder.append(")");
-          break;
-        case CONTAINS_KEY:
-          LiteralConstant[] kvp = convertExpressionToMapLiterals(filter.getRhs());
-          builder.append(convertExpressionToMapKeyColumn(filter.getLhs()));
-          builder.append(" = ");
-          builder.append(convertLiteralToString(kvp[MAP_KEY_INDEX], paramsBuilder));
-          break;
-        case CONTAINS_KEYVALUE:
-          kvp = convertExpressionToMapLiterals(filter.getRhs());
-          String keyCol = convertExpressionToMapKeyColumn(filter.getLhs());
-          String valCol = convertExpressionToMapValueColumn(filter.getLhs());
-          builder.append(keyCol);
-          builder.append(" = ");
-          builder.append(convertLiteralToString(kvp[MAP_KEY_INDEX], paramsBuilder));
-          builder.append(" AND ");
-          builder.append(valCol);
-          builder.append(" = ");
-          builder.append(convertLiteralToString(kvp[MAP_VALUE_INDEX], paramsBuilder));
-          builder.append(" AND ");
-          builder.append(MAP_VALUE);
-          builder.append("(");
-          builder.append(keyCol);
-          builder.append(",");
-          builder.append(convertLiteralToString(kvp[MAP_KEY_INDEX], paramsBuilder));
-          builder.append(",");
-          builder.append(valCol);
-          builder.append(") = ");
-          builder.append(convertLiteralToString(kvp[MAP_VALUE_INDEX], paramsBuilder));
-          break;
-        default:
-          rhs = handleValueConversionForLiteralExpression(filter.getLhs(), filter.getRhs());
-          builder.append(convertExpression2String(filter.getLhs(), paramsBuilder));
-          builder.append(" ");
-          builder.append(operator);
-          builder.append(" ");
-          builder.append(convertExpression2String(rhs, paramsBuilder));
-      }
-    }
-    return builder.toString();
-  }
-
-  /**
-   * Handles value conversion of a literal expression based on its associated column.
-   *
-   * @param lhs LHS expression with which literal is associated with
-   * @param rhs RHS expression which needs value conversion if its a literal expression
-   * @return newly created literal {@link Expression} of rhs if converted else the same one.
-   */
-  private Expression handleValueConversionForLiteralExpression(Expression lhs, Expression rhs) {
-    if (!(lhs.getValueCase().equals(COLUMNIDENTIFIER) && rhs.getValueCase().equals(LITERAL))) {
-      return rhs;
-    }
-
-    Expression newRhs = rhs;
-    String lhsColumnName = lhs.getColumnIdentifier().getColumnName();
-
-    if (viewDefinition.isBytesColumn(lhsColumnName)) {
-      ToValueConverter converter = getValueConverter(rhs.getLiteral().getValue().getValueType());
-      if (converter != null) {
-        try {
-          Value value = converter.convert(rhs.getLiteral().getValue().getString(), ValueType.BYTES);
-          newRhs = Expression.newBuilder()
-              .setLiteral(LiteralConstant.newBuilder().setValue(value))
-              .build();
-        } catch (Exception e) {
-          throw new IllegalArgumentException(
-              String.format("Invalid string input:{ %s } for bytes column:{ %s }",
-                  rhs.getLiteral().getValue().getString(),
-                  viewDefinition.getPhysicalColumnNames(lhsColumnName).get(0)));
-        }
-      }
-    }
-
-    return newRhs;
-  }
-
-  private ToValueConverter getValueConverter(ValueType valueType) {
-    ToValueConverter result;
-    switch (valueType) {
-      case STRING:
-        result = StringToValueConverter.INSTANCE;
-        break;
-      default:
-        result = null;
-        break;
-    }
-    return result;
-  }
-
-  private String convertOperator2String(Operator operator) {
-    switch (operator) {
-      case AND:
-        return "AND";
-      case OR:
-        return "OR";
-      case NOT:
-        return "NOT";
-      case EQ:
-        return "=";
-      case NEQ:
-        return "!=";
-      case IN:
-        return "IN";
-      case NOT_IN:
-        return "NOT IN";
-      case GT:
-        return ">";
-      case LT:
-        return "<";
-      case GE:
-        return ">=";
-      case LE:
-        return "<=";
-      case LIKE:
-        return REGEX_OPERATOR;
-      case CONTAINS_KEY:
-      case CONTAINS_KEYVALUE:
-        return MAP_VALUE;
-      case RANGE:
-        throw new UnsupportedOperationException("RANGE NOT supported use >= and <=");
-      case UNRECOGNIZED:
-      default:
-        throw new UnsupportedOperationException("Unknown operator:" + operator);
-    }
-  }
-
-  private String convertExpression2String(Expression expression, Params.Builder paramsBuilder) {
-    switch (expression.getValueCase()) {
-      case COLUMNIDENTIFIER:
-        String logicalColumnName = expression.getColumnIdentifier().getColumnName();
-        // this takes care of the Map Type where it's split into 2 columns
-        List<String> columnNames = viewDefinition.getPhysicalColumnNames(logicalColumnName);
-        return joiner.join(columnNames);
-      case LITERAL:
-        return convertLiteralToString(expression.getLiteral(), paramsBuilder);
-      case FUNCTION:
-        Function function = expression.getFunction();
-        String functionName = function.getFunctionName();
-        // For COUNT(column_name), Pinot sql format converts it to COUNT(*) and even only works with
-        // COUNT(*) for ORDER BY
-        if (functionName.equalsIgnoreCase("COUNT")) {
-          return functionName + "(*)";
-        }
-        List<Expression> argumentsList = function.getArgumentsList();
-        String[] args = new String[argumentsList.size()];
-        for (int i = 0; i < argumentsList.size(); i++) {
-          Expression expr = argumentsList.get(i);
-          args[i] = convertExpression2String(expr, paramsBuilder);
-        }
-        return functionName + "(" + joiner.join(args) + ")";
-      case ORDERBY:
-        OrderByExpression orderBy = expression.getOrderBy();
-        return convertExpression2String(orderBy.getExpression(), paramsBuilder);
-      case VALUE_NOT_SET:
-        break;
-    }
-    return "";
-  }
-
-  private String convertExpressionToMapKeyColumn(Expression expression) {
-    if (expression.getValueCase() == COLUMNIDENTIFIER) {
-      String logicalColumnName = expression.getColumnIdentifier().getColumnName();
-      String col = viewDefinition.getKeyColumnNameForMap(logicalColumnName);
-      if (col != null && col.length() > 0) {
-        return col;
-      }
-    }
-    throw new IllegalArgumentException(
-        "operator CONTAINS_KEY/KEYVALUE supports multi value column only");
-  }
-
-  private String convertExpressionToMapValueColumn(Expression expression) {
-    if (expression.getValueCase() == COLUMNIDENTIFIER) {
-      String logicalColumnName = expression.getColumnIdentifier().getColumnName();
-      String col = viewDefinition.getValueColumnNameForMap(logicalColumnName);
-      if (col != null && col.length() > 0) {
-        return col;
-      }
-    }
-    throw new IllegalArgumentException(
-        "operator CONTAINS_KEY/KEYVALUE supports multi value column only");
-  }
-
-  private LiteralConstant[] convertExpressionToMapLiterals(Expression expression) {
-    LiteralConstant[] literals = new LiteralConstant[2];
-    if (expression.getValueCase() == LITERAL) {
-      LiteralConstant value = expression.getLiteral();
-      if (value.getValue().getValueType() == ValueType.STRING_ARRAY) {
-        for (int i = 0; i < 2 && i < value.getValue().getStringArrayCount(); i++) {
-          literals[i] =
-              LiteralConstant.newBuilder()
-                  .setValue(
-                      Value.newBuilder().setString(value.getValue().getStringArray(i)).build())
-                  .build();
-        }
-      } else {
-        throw new IllegalArgumentException(
-            "operator CONTAINS_KEYVALUE supports "
-                + ValueType.STRING_ARRAY.name()
-                + " value type only");
-      }
-    }
-
-    for (int i = 0; i < literals.length; i++) {
-      if (literals[i] == null) {
-        literals[i] =
-            LiteralConstant.newBuilder().setValue(Value.newBuilder().setString("").build()).build();
-      }
-    }
-
-    return literals;
-  }
-
-  /**
-   * TODO:Handle all types
-   */
-  private String convertLiteralToString(LiteralConstant literal, Params.Builder paramsBuilder) {
-    Value value = literal.getValue();
-    String ret = null;
-    switch (value.getValueType()) {
-      case STRING_ARRAY:
-        StringBuilder builder = new StringBuilder("(");
+    Entry<String, Params> toSQL(
+            QueryContext queryContext, QueryRequest request, LinkedHashSet<Expression> allSelections) {
+        Params.Builder paramsBuilder = Params.newBuilder();
+        StringBuilder pqlBuilder = new StringBuilder("Select ");
         String delim = "";
-        for (String item : value.getStringArrayList()) {
-          builder.append(delim);
-          builder.append(QUESTION_MARK);
-          paramsBuilder.addStringParam(item);
-          delim = ", ";
+
+        // Set the DISTINCT keyword if the request has set distinctSelections.
+        if (request.getDistinctSelections()) {
+            pqlBuilder.append("DISTINCT ");
         }
-        builder.append(")");
-        ret = builder.toString();
-        break;
-      case LONG_ARRAY:
-        break;
-      case INT_ARRAY:
-        break;
-      case FLOAT_ARRAY:
-        break;
-      case DOUBLE_ARRAY:
-        break;
-      case BYTES_ARRAY:
-        break;
-      case BOOLEAN_ARRAY:
-        break;
-      case STRING:
-        ret = QUESTION_MARK;
-        paramsBuilder.addStringParam(value.getString());
-        break;
-      case LONG:
-        ret = QUESTION_MARK;
-        paramsBuilder.addLongParam(value.getLong());
-        break;
-      case INT:
-        ret = QUESTION_MARK;
-        paramsBuilder.addIntegerParam(value.getInt());
-        break;
-      case FLOAT:
-        ret = QUESTION_MARK;
-        paramsBuilder.addFloatParam(value.getFloat());
-        break;
-      case DOUBLE:
-        ret = QUESTION_MARK;
-        paramsBuilder.addDoubleParam(value.getDouble());
-        break;
-      case BYTES:
-        ret = QUESTION_MARK;
-        paramsBuilder.addBytesStringParam(Hex.encodeHexString(value.getBytes().toByteArray()));
-        break;
-      case BOOL:
-        ret = QUESTION_MARK;
-        paramsBuilder.addStringParam(String.valueOf(value.getBoolean()));
-        break;
-      case TIMESTAMP:
-        ret = QUESTION_MARK;
-        paramsBuilder.addLongParam(value.getTimestamp());
-        break;
-      case UNRECOGNIZED:
-        break;
+
+        // allSelections contain all the various expressions in QueryRequest that we want selections on.
+        // Group bys, selections and aggregations in that order. See RequestAnalyzer#analyze() to see
+        // how it is created.
+        for (Expression expr : allSelections) {
+            pqlBuilder.append(delim);
+            pqlBuilder.append(convertExpression2String(expr, paramsBuilder));
+            delim = ", ";
+        }
+
+        pqlBuilder.append(" FROM ").append(viewDefinition.getViewName());
+
+        // Add the tenantId filter
+        pqlBuilder.append(" WHERE ").append(viewDefinition.getTenantIdColumn()).append(" = ?");
+        paramsBuilder.addStringParam(queryContext.getTenantId());
+
+        if (request.hasFilter()) {
+            pqlBuilder.append(" AND ");
+            String filterClause = convertFilter2String(request.getFilter(), paramsBuilder);
+            pqlBuilder.append(filterClause);
+        }
+
+        if (request.getGroupByCount() > 0) {
+            pqlBuilder.append(" GROUP BY ");
+            delim = "";
+            for (Expression groupByExpression : request.getGroupByList()) {
+                pqlBuilder.append(delim);
+                pqlBuilder.append(convertExpression2String(groupByExpression, paramsBuilder));
+                delim = ", ";
+            }
+        }
+        if (!request.getOrderByList().isEmpty()) {
+            pqlBuilder.append(" ORDER BY ");
+            delim = "";
+            for (OrderByExpression orderByExpression : request.getOrderByList()) {
+                pqlBuilder.append(delim);
+                String orderBy = convertExpression2String(orderByExpression.getExpression(), paramsBuilder);
+                pqlBuilder.append(orderBy);
+                if (SortOrder.DESC.equals(orderByExpression.getOrder())) {
+                    pqlBuilder.append(" desc ");
+                }
+                delim = ", ";
+            }
+        }
+        if (request.getLimit() > 0) {
+            if (request.getOffset() > 0) {
+                pqlBuilder
+                        .append(" limit ")
+                        .append(request.getOffset())
+                        .append(", ")
+                        .append(request.getLimit());
+            } else {
+                pqlBuilder.append(" limit ").append(request.getLimit());
+            }
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Converted QueryRequest to Pinot SQL: {}", pqlBuilder);
+        }
+        return new SimpleEntry<>(pqlBuilder.toString(), paramsBuilder.build());
     }
-    return ret;
-  }
+
+    private String convertFilter2String(Filter filter, Params.Builder paramsBuilder) {
+        StringBuilder builder = new StringBuilder();
+        String operator = convertOperator2String(filter.getOperator());
+        if (filter.getChildFilterCount() > 0) {
+            String delim = "";
+            builder.append("( ");
+            for (Filter childFilter : filter.getChildFilterList()) {
+                builder.append(delim);
+                builder.append(convertFilter2String(childFilter, paramsBuilder));
+                builder.append(" ");
+                delim = operator + " ";
+            }
+            builder.append(")");
+        } else {
+            switch (filter.getOperator()) {
+                case LIKE:
+                    // The like operation in PQL looks like `regexp_like(lhs, rhs)`
+                    Expression rhs = handleValueConversionForLiteralExpression(filter.getLhs(), filter.getRhs());
+                    builder.append(operator);
+                    builder.append("(");
+                    builder.append(convertExpression2String(filter.getLhs(), paramsBuilder));
+                    builder.append(",");
+                    builder.append(convertExpression2String(rhs, paramsBuilder));
+                    builder.append(")");
+                    break;
+                case CONTAINS_KEY:
+                    LiteralConstant[] kvp = convertExpressionToMapLiterals(filter.getRhs());
+                    builder.append(convertExpressionToMapKeyColumn(filter.getLhs()));
+                    builder.append(" = ");
+                    builder.append(convertLiteralToString(kvp[MAP_KEY_INDEX], paramsBuilder));
+                    break;
+                case CONTAINS_KEYVALUE:
+                    kvp = convertExpressionToMapLiterals(filter.getRhs());
+                    String keyCol = convertExpressionToMapKeyColumn(filter.getLhs());
+                    String valCol = convertExpressionToMapValueColumn(filter.getLhs());
+                    builder.append(keyCol);
+                    builder.append(" = ");
+                    builder.append(convertLiteralToString(kvp[MAP_KEY_INDEX], paramsBuilder));
+                    builder.append(" AND ");
+                    builder.append(valCol);
+                    builder.append(" = ");
+                    builder.append(convertLiteralToString(kvp[MAP_VALUE_INDEX], paramsBuilder));
+                    builder.append(" AND ");
+                    builder.append(MAP_VALUE);
+                    builder.append("(");
+                    builder.append(keyCol);
+                    builder.append(",");
+                    builder.append(convertLiteralToString(kvp[MAP_KEY_INDEX], paramsBuilder));
+                    builder.append(",");
+                    builder.append(valCol);
+                    builder.append(") = ");
+                    builder.append(convertLiteralToString(kvp[MAP_VALUE_INDEX], paramsBuilder));
+                    break;
+                default:
+                    rhs = handleValueConversionForLiteralExpression(filter.getLhs(), filter.getRhs());
+                    builder.append(convertExpression2String(filter.getLhs(), paramsBuilder));
+                    builder.append(" ");
+                    builder.append(operator);
+                    builder.append(" ");
+                    builder.append(convertExpression2String(rhs, paramsBuilder));
+            }
+        }
+        return builder.toString();
+    }
+
+    /**
+     * Handles value conversion of a literal expression based on its associated column.
+     *
+     * @param lhs LHS expression with which literal is associated with
+     * @param rhs RHS expression which needs value conversion if its a literal expression
+     * @return newly created literal {@link Expression} of rhs if converted else the same one.
+     */
+    private Expression handleValueConversionForLiteralExpression(Expression lhs, Expression rhs) {
+        if (!(lhs.getValueCase().equals(COLUMNIDENTIFIER) && rhs.getValueCase().equals(LITERAL))) {
+            return rhs;
+        }
+
+        Expression newRhs = rhs;
+        String lhsColumnName = lhs.getColumnIdentifier().getColumnName();
+
+        ToValueConverter converter = getValueConverter(rhs.getLiteral().getValue().getValueType());
+        if (converter != null) {
+            try {
+                Value value = converter.convert(rhs.getLiteral().getValue().getString(),
+                        viewDefinition.getColumnType(lhsColumnName));
+                newRhs = Expression.newBuilder()
+                        .setLiteral(LiteralConstant.newBuilder().setValue(value))
+                        .build();
+            } catch (Exception e) {
+                throw new IllegalArgumentException(
+                        String.format("Invalid string input:{ %s } for bytes column:{ %s }",
+                                rhs.getLiteral().getValue().getString(),
+                                viewDefinition.getPhysicalColumnNames(lhsColumnName).get(0)));
+            }
+        }
+
+        return newRhs;
+    }
+
+    private ToValueConverter getValueConverter(ValueType valueType) {
+        ToValueConverter result;
+        switch (valueType) {
+            case STRING:
+                result = StringToValueConverter.INSTANCE;
+                break;
+            default:
+                result = null;
+                break;
+        }
+        return result;
+    }
+
+    private String convertOperator2String(Operator operator) {
+        switch (operator) {
+            case AND:
+                return "AND";
+            case OR:
+                return "OR";
+            case NOT:
+                return "NOT";
+            case EQ:
+                return "=";
+            case NEQ:
+                return "!=";
+            case IN:
+                return "IN";
+            case NOT_IN:
+                return "NOT IN";
+            case GT:
+                return ">";
+            case LT:
+                return "<";
+            case GE:
+                return ">=";
+            case LE:
+                return "<=";
+            case LIKE:
+                return REGEX_OPERATOR;
+            case CONTAINS_KEY:
+            case CONTAINS_KEYVALUE:
+                return MAP_VALUE;
+            case RANGE:
+                throw new UnsupportedOperationException("RANGE NOT supported use >= and <=");
+            case UNRECOGNIZED:
+            default:
+                throw new UnsupportedOperationException("Unknown operator:" + operator);
+        }
+    }
+
+    private String convertExpression2String(Expression expression, Params.Builder paramsBuilder) {
+        switch (expression.getValueCase()) {
+            case COLUMNIDENTIFIER:
+                String logicalColumnName = expression.getColumnIdentifier().getColumnName();
+                // this takes care of the Map Type where it's split into 2 columns
+                List<String> columnNames = viewDefinition.getPhysicalColumnNames(logicalColumnName);
+                return joiner.join(columnNames);
+            case LITERAL:
+                return convertLiteralToString(expression.getLiteral(), paramsBuilder);
+            case FUNCTION:
+                Function function = expression.getFunction();
+                String functionName = function.getFunctionName();
+                // For COUNT(column_name), Pinot sql format converts it to COUNT(*) and even only works with
+                // COUNT(*) for ORDER BY
+                if (functionName.equalsIgnoreCase("COUNT")) {
+                    return functionName + "(*)";
+                }
+                List<Expression> argumentsList = function.getArgumentsList();
+                String[] args = new String[argumentsList.size()];
+                for (int i = 0; i < argumentsList.size(); i++) {
+                    Expression expr = argumentsList.get(i);
+                    args[i] = convertExpression2String(expr, paramsBuilder);
+                }
+                return functionName + "(" + joiner.join(args) + ")";
+            case ORDERBY:
+                OrderByExpression orderBy = expression.getOrderBy();
+                return convertExpression2String(orderBy.getExpression(), paramsBuilder);
+            case VALUE_NOT_SET:
+                break;
+        }
+        return "";
+    }
+
+    private String convertExpressionToMapKeyColumn(Expression expression) {
+        if (expression.getValueCase() == COLUMNIDENTIFIER) {
+            String logicalColumnName = expression.getColumnIdentifier().getColumnName();
+            String col = viewDefinition.getKeyColumnNameForMap(logicalColumnName);
+            if (col != null && col.length() > 0) {
+                return col;
+            }
+        }
+        throw new IllegalArgumentException(
+                "operator CONTAINS_KEY/KEYVALUE supports multi value column only");
+    }
+
+    private String convertExpressionToMapValueColumn(Expression expression) {
+        if (expression.getValueCase() == COLUMNIDENTIFIER) {
+            String logicalColumnName = expression.getColumnIdentifier().getColumnName();
+            String col = viewDefinition.getValueColumnNameForMap(logicalColumnName);
+            if (col != null && col.length() > 0) {
+                return col;
+            }
+        }
+        throw new IllegalArgumentException(
+                "operator CONTAINS_KEY/KEYVALUE supports multi value column only");
+    }
+
+    private LiteralConstant[] convertExpressionToMapLiterals(Expression expression) {
+        LiteralConstant[] literals = new LiteralConstant[2];
+        if (expression.getValueCase() == LITERAL) {
+            LiteralConstant value = expression.getLiteral();
+            if (value.getValue().getValueType() == ValueType.STRING_ARRAY) {
+                for (int i = 0; i < 2 && i < value.getValue().getStringArrayCount(); i++) {
+                    literals[i] =
+                            LiteralConstant.newBuilder()
+                                    .setValue(
+                                            Value.newBuilder().setString(value.getValue().getStringArray(i)).build())
+                                    .build();
+                }
+            } else {
+                throw new IllegalArgumentException(
+                        "operator CONTAINS_KEYVALUE supports "
+                                + ValueType.STRING_ARRAY.name()
+                                + " value type only");
+            }
+        }
+
+        for (int i = 0; i < literals.length; i++) {
+            if (literals[i] == null) {
+                literals[i] =
+                        LiteralConstant.newBuilder().setValue(Value.newBuilder().setString("").build()).build();
+            }
+        }
+
+        return literals;
+    }
+
+    /**
+     * TODO:Handle all types
+     */
+    private String convertLiteralToString(LiteralConstant literal, Params.Builder paramsBuilder) {
+        Value value = literal.getValue();
+        String ret = null;
+        switch (value.getValueType()) {
+            case STRING_ARRAY:
+                StringBuilder builder = new StringBuilder("(");
+                String delim = "";
+                for (String item : value.getStringArrayList()) {
+                    builder.append(delim);
+                    builder.append(QUESTION_MARK);
+                    paramsBuilder.addStringParam(item);
+                    delim = ", ";
+                }
+                builder.append(")");
+                ret = builder.toString();
+                break;
+            case LONG_ARRAY:
+                break;
+            case INT_ARRAY:
+                break;
+            case FLOAT_ARRAY:
+                break;
+            case DOUBLE_ARRAY:
+                break;
+            case BYTES_ARRAY:
+                break;
+            case BOOLEAN_ARRAY:
+                break;
+            case STRING:
+                ret = QUESTION_MARK;
+                paramsBuilder.addStringParam(value.getString());
+                break;
+            case LONG:
+                ret = QUESTION_MARK;
+                paramsBuilder.addLongParam(value.getLong());
+                break;
+            case INT:
+                ret = QUESTION_MARK;
+                paramsBuilder.addIntegerParam(value.getInt());
+                break;
+            case FLOAT:
+                ret = QUESTION_MARK;
+                paramsBuilder.addFloatParam(value.getFloat());
+                break;
+            case DOUBLE:
+                ret = QUESTION_MARK;
+                paramsBuilder.addDoubleParam(value.getDouble());
+                break;
+            case BYTES:
+                ret = QUESTION_MARK;
+                paramsBuilder.addBytesStringParam(Hex.encodeHexString(value.getBytes().toByteArray()));
+                break;
+            case BOOL:
+                ret = QUESTION_MARK;
+                paramsBuilder.addStringParam(String.valueOf(value.getBoolean()));
+                break;
+            case TIMESTAMP:
+                ret = QUESTION_MARK;
+                paramsBuilder.addLongParam(value.getTimestamp());
+                break;
+            case UNRECOGNIZED:
+                break;
+        }
+        return ret;
+    }
 }

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
@@ -197,20 +197,19 @@ class QueryRequestToPinotSQLConverter {
     Expression newRhs = rhs;
     String lhsColumnName = lhs.getColumnIdentifier().getColumnName();
 
-    if (viewDefinition.isBytesColumn(lhsColumnName)) {
-      ToValueConverter converter = getValueConverter(rhs.getLiteral().getValue().getValueType());
-      if (converter != null) {
-        try {
-          Value value = converter.convert(rhs.getLiteral().getValue().getString(), ValueType.BYTES);
-          newRhs = Expression.newBuilder()
-              .setLiteral(LiteralConstant.newBuilder().setValue(value))
-              .build();
-        } catch (Exception e) {
-          throw new IllegalArgumentException(
-              String.format("Invalid string input:{ %s } for bytes column:{ %s }",
-                  rhs.getLiteral().getValue().getString(),
-                  viewDefinition.getPhysicalColumnNames(lhsColumnName).get(0)));
-        }
+    ToValueConverter converter = getValueConverter(rhs.getLiteral().getValue().getValueType());
+    if (converter != null) {
+      try {
+        Value value = converter.convert(rhs.getLiteral().getValue().getString(),
+                viewDefinition.getColumnType(lhsColumnName));
+        newRhs = Expression.newBuilder()
+            .setLiteral(LiteralConstant.newBuilder().setValue(value))
+            .build();
+      } catch (Exception e) {
+        throw new IllegalArgumentException(
+            String.format("Invalid string input:{ %s } for bytes column:{ %s }",
+                rhs.getLiteral().getValue().getString(),
+                viewDefinition.getPhysicalColumnNames(lhsColumnName).get(0)));
       }
     }
 

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
@@ -8,6 +8,7 @@ import java.util.AbstractMap.SimpleEntry;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map.Entry;
+import org.apache.commons.codec.binary.Hex;
 import org.hypertrace.core.query.service.QueryContext;
 import org.hypertrace.core.query.service.api.Expression;
 import org.hypertrace.core.query.service.api.Filter;
@@ -19,11 +20,16 @@ import org.hypertrace.core.query.service.api.QueryRequest;
 import org.hypertrace.core.query.service.api.SortOrder;
 import org.hypertrace.core.query.service.api.Value;
 import org.hypertrace.core.query.service.api.ValueType;
+import org.hypertrace.core.query.service.pinot.converters.StringToValueConverter;
+import org.hypertrace.core.query.service.pinot.converters.ToValueConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Converts {@link QueryRequest} to Pinot SQL query */
+/**
+ * Converts {@link QueryRequest} to Pinot SQL query
+ */
 class QueryRequestToPinotSQLConverter {
+
   private static final Logger LOG = LoggerFactory.getLogger(QueryRequestToPinotSQLConverter.class);
 
   private static final String QUESTION_MARK = "?";
@@ -128,11 +134,12 @@ class QueryRequestToPinotSQLConverter {
       switch (filter.getOperator()) {
         case LIKE:
           // The like operation in PQL looks like `regexp_like(lhs, rhs)`
+          Expression rhs = handleValueConversionForLiteralExpression(filter.getLhs(), filter.getRhs());
           builder.append(operator);
           builder.append("(");
           builder.append(convertExpression2String(filter.getLhs(), paramsBuilder));
           builder.append(",");
-          builder.append(convertExpression2String(filter.getRhs(), paramsBuilder));
+          builder.append(convertExpression2String(rhs, paramsBuilder));
           builder.append(")");
           break;
         case CONTAINS_KEY:
@@ -164,14 +171,63 @@ class QueryRequestToPinotSQLConverter {
           builder.append(convertLiteralToString(kvp[MAP_VALUE_INDEX], paramsBuilder));
           break;
         default:
+          rhs = handleValueConversionForLiteralExpression(filter.getLhs(), filter.getRhs());
           builder.append(convertExpression2String(filter.getLhs(), paramsBuilder));
           builder.append(" ");
           builder.append(operator);
           builder.append(" ");
-          builder.append(convertExpression2String(filter.getRhs(), paramsBuilder));
+          builder.append(convertExpression2String(rhs, paramsBuilder));
       }
     }
     return builder.toString();
+  }
+
+  /**
+   * Handles value conversion of a literal expression based on its associated column.
+   *
+   * @param lhs LHS expression with which literal is associated with
+   * @param rhs RHS expression which needs value conversion if its a literal expression
+   * @return newly created literal {@link Expression} of rhs if converted else the same one.
+   */
+  private Expression handleValueConversionForLiteralExpression(Expression lhs, Expression rhs) {
+    if (!(lhs.getValueCase().equals(COLUMNIDENTIFIER) && rhs.getValueCase().equals(LITERAL))) {
+      return rhs;
+    }
+
+    Expression newRhs = rhs;
+    String lhsColumnName = lhs.getColumnIdentifier().getColumnName();
+
+    if (viewDefinition.isBytesColumn(lhsColumnName)) {
+      ToValueConverter converter = getValueConverter(rhs.getLiteral().getValue().getValueType());
+      if (converter != null) {
+        try {
+          Value value = converter.convert(rhs.getLiteral().getValue().getString(), ValueType.BYTES);
+          newRhs = Expression.newBuilder()
+              .setLiteral(LiteralConstant.newBuilder().setValue(value))
+              .build();
+        } catch (Exception e) {
+          throw new IllegalArgumentException(
+              String.format("Invalid string input:{ %s } for bytes column:{ %s }",
+                  rhs.getLiteral().getValue().getString(),
+                  viewDefinition.getPhysicalColumnNames(lhsColumnName).get(0)));
+        }
+      }
+    }
+
+    return newRhs;
+  }
+
+  private ToValueConverter getValueConverter(ValueType valueType) {
+    ToValueConverter result;
+    switch (valueType) {
+      case STRING:
+        result = StringToValueConverter.INSTANCE;
+        break;
+      default:
+        result = null;
+        break;
+    }
+    return result;
   }
 
   private String convertOperator2String(Operator operator) {
@@ -298,7 +354,9 @@ class QueryRequestToPinotSQLConverter {
     return literals;
   }
 
-  /** TODO:Handle all types */
+  /**
+   * TODO:Handle all types
+   */
   private String convertLiteralToString(LiteralConstant literal, Params.Builder paramsBuilder) {
     Value value = literal.getValue();
     String ret = null;
@@ -348,6 +406,8 @@ class QueryRequestToPinotSQLConverter {
         paramsBuilder.addDoubleParam(value.getDouble());
         break;
       case BYTES:
+        ret = QUESTION_MARK;
+        paramsBuilder.addBytesStringParam(Hex.encodeHexString(value.getBytes().toByteArray()));
         break;
       case BOOL:
         ret = QUESTION_MARK;

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
@@ -30,395 +30,396 @@ import org.slf4j.LoggerFactory;
  */
 class QueryRequestToPinotSQLConverter {
 
-    private static final Logger LOG = LoggerFactory.getLogger(QueryRequestToPinotSQLConverter.class);
+  private static final Logger LOG = LoggerFactory.getLogger(QueryRequestToPinotSQLConverter.class);
 
-    private static final String QUESTION_MARK = "?";
-    private static final String REGEX_OPERATOR = "REGEXP_LIKE";
-    private static final String MAP_VALUE = "mapValue";
-    private static final int MAP_KEY_INDEX = 0;
-    private static final int MAP_VALUE_INDEX = 1;
+  private static final String QUESTION_MARK = "?";
+  private static final String REGEX_OPERATOR = "REGEXP_LIKE";
+  private static final String MAP_VALUE = "mapValue";
+  private static final int MAP_KEY_INDEX = 0;
+  private static final int MAP_VALUE_INDEX = 1;
 
-    private ViewDefinition viewDefinition;
-    private Joiner joiner = Joiner.on(", ").skipNulls();
+  private ViewDefinition viewDefinition;
+  private Joiner joiner = Joiner.on(", ").skipNulls();
 
-    QueryRequestToPinotSQLConverter(ViewDefinition viewDefinition) {
-        this.viewDefinition = viewDefinition;
+  QueryRequestToPinotSQLConverter(ViewDefinition viewDefinition) {
+    this.viewDefinition = viewDefinition;
+  }
+
+  Entry<String, Params> toSQL(
+      QueryContext queryContext, QueryRequest request, LinkedHashSet<Expression> allSelections) {
+    Params.Builder paramsBuilder = Params.newBuilder();
+    StringBuilder pqlBuilder = new StringBuilder("Select ");
+    String delim = "";
+
+    // Set the DISTINCT keyword if the request has set distinctSelections.
+    if (request.getDistinctSelections()) {
+      pqlBuilder.append("DISTINCT ");
     }
 
-    Entry<String, Params> toSQL(
-            QueryContext queryContext, QueryRequest request, LinkedHashSet<Expression> allSelections) {
-        Params.Builder paramsBuilder = Params.newBuilder();
-        StringBuilder pqlBuilder = new StringBuilder("Select ");
+    // allSelections contain all the various expressions in QueryRequest that we want selections on.
+    // Group bys, selections and aggregations in that order. See RequestAnalyzer#analyze() to see
+    // how it is created.
+    for (Expression expr : allSelections) {
+      pqlBuilder.append(delim);
+      pqlBuilder.append(convertExpression2String(expr, paramsBuilder));
+      delim = ", ";
+    }
+
+    pqlBuilder.append(" FROM ").append(viewDefinition.getViewName());
+
+    // Add the tenantId filter
+    pqlBuilder.append(" WHERE ").append(viewDefinition.getTenantIdColumn()).append(" = ?");
+    paramsBuilder.addStringParam(queryContext.getTenantId());
+
+    if (request.hasFilter()) {
+      pqlBuilder.append(" AND ");
+      String filterClause = convertFilter2String(request.getFilter(), paramsBuilder);
+      pqlBuilder.append(filterClause);
+    }
+
+    if (request.getGroupByCount() > 0) {
+      pqlBuilder.append(" GROUP BY ");
+      delim = "";
+      for (Expression groupByExpression : request.getGroupByList()) {
+        pqlBuilder.append(delim);
+        pqlBuilder.append(convertExpression2String(groupByExpression, paramsBuilder));
+        delim = ", ";
+      }
+    }
+    if (!request.getOrderByList().isEmpty()) {
+      pqlBuilder.append(" ORDER BY ");
+      delim = "";
+      for (OrderByExpression orderByExpression : request.getOrderByList()) {
+        pqlBuilder.append(delim);
+        String orderBy = convertExpression2String(orderByExpression.getExpression(), paramsBuilder);
+        pqlBuilder.append(orderBy);
+        if (SortOrder.DESC.equals(orderByExpression.getOrder())) {
+          pqlBuilder.append(" desc ");
+        }
+        delim = ", ";
+      }
+    }
+    if (request.getLimit() > 0) {
+      if (request.getOffset() > 0) {
+        pqlBuilder
+            .append(" limit ")
+            .append(request.getOffset())
+            .append(", ")
+            .append(request.getLimit());
+      } else {
+        pqlBuilder.append(" limit ").append(request.getLimit());
+      }
+    }
+
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Converted QueryRequest to Pinot SQL: {}", pqlBuilder);
+    }
+    return new SimpleEntry<>(pqlBuilder.toString(), paramsBuilder.build());
+  }
+
+  private String convertFilter2String(Filter filter, Params.Builder paramsBuilder) {
+    StringBuilder builder = new StringBuilder();
+    String operator = convertOperator2String(filter.getOperator());
+    if (filter.getChildFilterCount() > 0) {
+      String delim = "";
+      builder.append("( ");
+      for (Filter childFilter : filter.getChildFilterList()) {
+        builder.append(delim);
+        builder.append(convertFilter2String(childFilter, paramsBuilder));
+        builder.append(" ");
+        delim = operator + " ";
+      }
+      builder.append(")");
+    } else {
+      switch (filter.getOperator()) {
+        case LIKE:
+          // The like operation in PQL looks like `regexp_like(lhs, rhs)`
+          Expression rhs = handleValueConversionForLiteralExpression(filter.getLhs(), filter.getRhs());
+          builder.append(operator);
+          builder.append("(");
+          builder.append(convertExpression2String(filter.getLhs(), paramsBuilder));
+          builder.append(",");
+          builder.append(convertExpression2String(rhs, paramsBuilder));
+          builder.append(")");
+          break;
+        case CONTAINS_KEY:
+          LiteralConstant[] kvp = convertExpressionToMapLiterals(filter.getRhs());
+          builder.append(convertExpressionToMapKeyColumn(filter.getLhs()));
+          builder.append(" = ");
+          builder.append(convertLiteralToString(kvp[MAP_KEY_INDEX], paramsBuilder));
+          break;
+        case CONTAINS_KEYVALUE:
+          kvp = convertExpressionToMapLiterals(filter.getRhs());
+          String keyCol = convertExpressionToMapKeyColumn(filter.getLhs());
+          String valCol = convertExpressionToMapValueColumn(filter.getLhs());
+          builder.append(keyCol);
+          builder.append(" = ");
+          builder.append(convertLiteralToString(kvp[MAP_KEY_INDEX], paramsBuilder));
+          builder.append(" AND ");
+          builder.append(valCol);
+          builder.append(" = ");
+          builder.append(convertLiteralToString(kvp[MAP_VALUE_INDEX], paramsBuilder));
+          builder.append(" AND ");
+          builder.append(MAP_VALUE);
+          builder.append("(");
+          builder.append(keyCol);
+          builder.append(",");
+          builder.append(convertLiteralToString(kvp[MAP_KEY_INDEX], paramsBuilder));
+          builder.append(",");
+          builder.append(valCol);
+          builder.append(") = ");
+          builder.append(convertLiteralToString(kvp[MAP_VALUE_INDEX], paramsBuilder));
+          break;
+        default:
+          rhs = handleValueConversionForLiteralExpression(filter.getLhs(), filter.getRhs());
+          builder.append(convertExpression2String(filter.getLhs(), paramsBuilder));
+          builder.append(" ");
+          builder.append(operator);
+          builder.append(" ");
+          builder.append(convertExpression2String(rhs, paramsBuilder));
+      }
+    }
+    return builder.toString();
+  }
+
+  /**
+   * Handles value conversion of a literal expression based on its associated column.
+   *
+   * @param lhs LHS expression with which literal is associated with
+   * @param rhs RHS expression which needs value conversion if its a literal expression
+   * @return newly created literal {@link Expression} of rhs if converted else the same one.
+   */
+  private Expression handleValueConversionForLiteralExpression(Expression lhs, Expression rhs) {
+    if (!(lhs.getValueCase().equals(COLUMNIDENTIFIER) && rhs.getValueCase().equals(LITERAL))) {
+      return rhs;
+    }
+
+    Expression newRhs = rhs;
+    String lhsColumnName = lhs.getColumnIdentifier().getColumnName();
+
+    if (viewDefinition.isBytesColumn(lhsColumnName)) {
+      ToValueConverter converter = getValueConverter(rhs.getLiteral().getValue().getValueType());
+      if (converter != null) {
+        try {
+          Value value = converter.convert(rhs.getLiteral().getValue().getString(), ValueType.BYTES);
+          newRhs = Expression.newBuilder()
+              .setLiteral(LiteralConstant.newBuilder().setValue(value))
+              .build();
+        } catch (Exception e) {
+          throw new IllegalArgumentException(
+              String.format("Invalid string input:{ %s } for bytes column:{ %s }",
+                  rhs.getLiteral().getValue().getString(),
+                  viewDefinition.getPhysicalColumnNames(lhsColumnName).get(0)));
+        }
+      }
+    }
+
+    return newRhs;
+  }
+
+  private ToValueConverter getValueConverter(ValueType valueType) {
+    ToValueConverter result;
+    switch (valueType) {
+      case STRING:
+        result = StringToValueConverter.INSTANCE;
+        break;
+      default:
+        result = null;
+        break;
+    }
+    return result;
+  }
+
+  private String convertOperator2String(Operator operator) {
+    switch (operator) {
+      case AND:
+        return "AND";
+      case OR:
+        return "OR";
+      case NOT:
+        return "NOT";
+      case EQ:
+        return "=";
+      case NEQ:
+        return "!=";
+      case IN:
+        return "IN";
+      case NOT_IN:
+        return "NOT IN";
+      case GT:
+        return ">";
+      case LT:
+        return "<";
+      case GE:
+        return ">=";
+      case LE:
+        return "<=";
+      case LIKE:
+        return REGEX_OPERATOR;
+      case CONTAINS_KEY:
+      case CONTAINS_KEYVALUE:
+        return MAP_VALUE;
+      case RANGE:
+        throw new UnsupportedOperationException("RANGE NOT supported use >= and <=");
+      case UNRECOGNIZED:
+      default:
+        throw new UnsupportedOperationException("Unknown operator:" + operator);
+    }
+  }
+
+  private String convertExpression2String(Expression expression, Params.Builder paramsBuilder) {
+    switch (expression.getValueCase()) {
+      case COLUMNIDENTIFIER:
+        String logicalColumnName = expression.getColumnIdentifier().getColumnName();
+        // this takes care of the Map Type where it's split into 2 columns
+        List<String> columnNames = viewDefinition.getPhysicalColumnNames(logicalColumnName);
+        return joiner.join(columnNames);
+      case LITERAL:
+        return convertLiteralToString(expression.getLiteral(), paramsBuilder);
+      case FUNCTION:
+        Function function = expression.getFunction();
+        String functionName = function.getFunctionName();
+        // For COUNT(column_name), Pinot sql format converts it to COUNT(*) and even only works with
+        // COUNT(*) for ORDER BY
+        if (functionName.equalsIgnoreCase("COUNT")) {
+          return functionName + "(*)";
+        }
+        List<Expression> argumentsList = function.getArgumentsList();
+        String[] args = new String[argumentsList.size()];
+        for (int i = 0; i < argumentsList.size(); i++) {
+          Expression expr = argumentsList.get(i);
+          args[i] = convertExpression2String(expr, paramsBuilder);
+        }
+        return functionName + "(" + joiner.join(args) + ")";
+      case ORDERBY:
+        OrderByExpression orderBy = expression.getOrderBy();
+        return convertExpression2String(orderBy.getExpression(), paramsBuilder);
+      case VALUE_NOT_SET:
+        break;
+    }
+    return "";
+  }
+
+  private String convertExpressionToMapKeyColumn(Expression expression) {
+    if (expression.getValueCase() == COLUMNIDENTIFIER) {
+      String logicalColumnName = expression.getColumnIdentifier().getColumnName();
+      String col = viewDefinition.getKeyColumnNameForMap(logicalColumnName);
+      if (col != null && col.length() > 0) {
+        return col;
+      }
+    }
+    throw new IllegalArgumentException(
+        "operator CONTAINS_KEY/KEYVALUE supports multi value column only");
+  }
+
+  private String convertExpressionToMapValueColumn(Expression expression) {
+    if (expression.getValueCase() == COLUMNIDENTIFIER) {
+      String logicalColumnName = expression.getColumnIdentifier().getColumnName();
+      String col = viewDefinition.getValueColumnNameForMap(logicalColumnName);
+      if (col != null && col.length() > 0) {
+        return col;
+      }
+    }
+    throw new IllegalArgumentException(
+        "operator CONTAINS_KEY/KEYVALUE supports multi value column only");
+  }
+
+  private LiteralConstant[] convertExpressionToMapLiterals(Expression expression) {
+    LiteralConstant[] literals = new LiteralConstant[2];
+    if (expression.getValueCase() == LITERAL) {
+      LiteralConstant value = expression.getLiteral();
+      if (value.getValue().getValueType() == ValueType.STRING_ARRAY) {
+        for (int i = 0; i < 2 && i < value.getValue().getStringArrayCount(); i++) {
+          literals[i] =
+              LiteralConstant.newBuilder()
+                  .setValue(
+                      Value.newBuilder().setString(value.getValue().getStringArray(i)).build())
+                  .build();
+        }
+      } else {
+        throw new IllegalArgumentException(
+            "operator CONTAINS_KEYVALUE supports "
+                + ValueType.STRING_ARRAY.name()
+                + " value type only");
+      }
+    }
+
+    for (int i = 0; i < literals.length; i++) {
+      if (literals[i] == null) {
+        literals[i] =
+            LiteralConstant.newBuilder().setValue(Value.newBuilder().setString("").build()).build();
+      }
+    }
+
+    return literals;
+  }
+
+  /**
+   * TODO:Handle all types
+   */
+  private String convertLiteralToString(LiteralConstant literal, Params.Builder paramsBuilder) {
+    Value value = literal.getValue();
+    String ret = null;
+    switch (value.getValueType()) {
+      case STRING_ARRAY:
+        StringBuilder builder = new StringBuilder("(");
         String delim = "";
-
-        // Set the DISTINCT keyword if the request has set distinctSelections.
-        if (request.getDistinctSelections()) {
-            pqlBuilder.append("DISTINCT ");
+        for (String item : value.getStringArrayList()) {
+          builder.append(delim);
+          builder.append(QUESTION_MARK);
+          paramsBuilder.addStringParam(item);
+          delim = ", ";
         }
-
-        // allSelections contain all the various expressions in QueryRequest that we want selections on.
-        // Group bys, selections and aggregations in that order. See RequestAnalyzer#analyze() to see
-        // how it is created.
-        for (Expression expr : allSelections) {
-            pqlBuilder.append(delim);
-            pqlBuilder.append(convertExpression2String(expr, paramsBuilder));
-            delim = ", ";
-        }
-
-        pqlBuilder.append(" FROM ").append(viewDefinition.getViewName());
-
-        // Add the tenantId filter
-        pqlBuilder.append(" WHERE ").append(viewDefinition.getTenantIdColumn()).append(" = ?");
-        paramsBuilder.addStringParam(queryContext.getTenantId());
-
-        if (request.hasFilter()) {
-            pqlBuilder.append(" AND ");
-            String filterClause = convertFilter2String(request.getFilter(), paramsBuilder);
-            pqlBuilder.append(filterClause);
-        }
-
-        if (request.getGroupByCount() > 0) {
-            pqlBuilder.append(" GROUP BY ");
-            delim = "";
-            for (Expression groupByExpression : request.getGroupByList()) {
-                pqlBuilder.append(delim);
-                pqlBuilder.append(convertExpression2String(groupByExpression, paramsBuilder));
-                delim = ", ";
-            }
-        }
-        if (!request.getOrderByList().isEmpty()) {
-            pqlBuilder.append(" ORDER BY ");
-            delim = "";
-            for (OrderByExpression orderByExpression : request.getOrderByList()) {
-                pqlBuilder.append(delim);
-                String orderBy = convertExpression2String(orderByExpression.getExpression(), paramsBuilder);
-                pqlBuilder.append(orderBy);
-                if (SortOrder.DESC.equals(orderByExpression.getOrder())) {
-                    pqlBuilder.append(" desc ");
-                }
-                delim = ", ";
-            }
-        }
-        if (request.getLimit() > 0) {
-            if (request.getOffset() > 0) {
-                pqlBuilder
-                        .append(" limit ")
-                        .append(request.getOffset())
-                        .append(", ")
-                        .append(request.getLimit());
-            } else {
-                pqlBuilder.append(" limit ").append(request.getLimit());
-            }
-        }
-
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Converted QueryRequest to Pinot SQL: {}", pqlBuilder);
-        }
-        return new SimpleEntry<>(pqlBuilder.toString(), paramsBuilder.build());
+        builder.append(")");
+        ret = builder.toString();
+        break;
+      case LONG_ARRAY:
+        break;
+      case INT_ARRAY:
+        break;
+      case FLOAT_ARRAY:
+        break;
+      case DOUBLE_ARRAY:
+        break;
+      case BYTES_ARRAY:
+        break;
+      case BOOLEAN_ARRAY:
+        break;
+      case STRING:
+        ret = QUESTION_MARK;
+        paramsBuilder.addStringParam(value.getString());
+        break;
+      case LONG:
+        ret = QUESTION_MARK;
+        paramsBuilder.addLongParam(value.getLong());
+        break;
+      case INT:
+        ret = QUESTION_MARK;
+        paramsBuilder.addIntegerParam(value.getInt());
+        break;
+      case FLOAT:
+        ret = QUESTION_MARK;
+        paramsBuilder.addFloatParam(value.getFloat());
+        break;
+      case DOUBLE:
+        ret = QUESTION_MARK;
+        paramsBuilder.addDoubleParam(value.getDouble());
+        break;
+      case BYTES:
+        ret = QUESTION_MARK;
+        paramsBuilder.addBytesStringParam(Hex.encodeHexString(value.getBytes().toByteArray()));
+        break;
+      case BOOL:
+        ret = QUESTION_MARK;
+        paramsBuilder.addStringParam(String.valueOf(value.getBoolean()));
+        break;
+      case TIMESTAMP:
+        ret = QUESTION_MARK;
+        paramsBuilder.addLongParam(value.getTimestamp());
+        break;
+      case UNRECOGNIZED:
+        break;
     }
-
-    private String convertFilter2String(Filter filter, Params.Builder paramsBuilder) {
-        StringBuilder builder = new StringBuilder();
-        String operator = convertOperator2String(filter.getOperator());
-        if (filter.getChildFilterCount() > 0) {
-            String delim = "";
-            builder.append("( ");
-            for (Filter childFilter : filter.getChildFilterList()) {
-                builder.append(delim);
-                builder.append(convertFilter2String(childFilter, paramsBuilder));
-                builder.append(" ");
-                delim = operator + " ";
-            }
-            builder.append(")");
-        } else {
-            switch (filter.getOperator()) {
-                case LIKE:
-                    // The like operation in PQL looks like `regexp_like(lhs, rhs)`
-                    Expression rhs = handleValueConversionForLiteralExpression(filter.getLhs(), filter.getRhs());
-                    builder.append(operator);
-                    builder.append("(");
-                    builder.append(convertExpression2String(filter.getLhs(), paramsBuilder));
-                    builder.append(",");
-                    builder.append(convertExpression2String(rhs, paramsBuilder));
-                    builder.append(")");
-                    break;
-                case CONTAINS_KEY:
-                    LiteralConstant[] kvp = convertExpressionToMapLiterals(filter.getRhs());
-                    builder.append(convertExpressionToMapKeyColumn(filter.getLhs()));
-                    builder.append(" = ");
-                    builder.append(convertLiteralToString(kvp[MAP_KEY_INDEX], paramsBuilder));
-                    break;
-                case CONTAINS_KEYVALUE:
-                    kvp = convertExpressionToMapLiterals(filter.getRhs());
-                    String keyCol = convertExpressionToMapKeyColumn(filter.getLhs());
-                    String valCol = convertExpressionToMapValueColumn(filter.getLhs());
-                    builder.append(keyCol);
-                    builder.append(" = ");
-                    builder.append(convertLiteralToString(kvp[MAP_KEY_INDEX], paramsBuilder));
-                    builder.append(" AND ");
-                    builder.append(valCol);
-                    builder.append(" = ");
-                    builder.append(convertLiteralToString(kvp[MAP_VALUE_INDEX], paramsBuilder));
-                    builder.append(" AND ");
-                    builder.append(MAP_VALUE);
-                    builder.append("(");
-                    builder.append(keyCol);
-                    builder.append(",");
-                    builder.append(convertLiteralToString(kvp[MAP_KEY_INDEX], paramsBuilder));
-                    builder.append(",");
-                    builder.append(valCol);
-                    builder.append(") = ");
-                    builder.append(convertLiteralToString(kvp[MAP_VALUE_INDEX], paramsBuilder));
-                    break;
-                default:
-                    rhs = handleValueConversionForLiteralExpression(filter.getLhs(), filter.getRhs());
-                    builder.append(convertExpression2String(filter.getLhs(), paramsBuilder));
-                    builder.append(" ");
-                    builder.append(operator);
-                    builder.append(" ");
-                    builder.append(convertExpression2String(rhs, paramsBuilder));
-            }
-        }
-        return builder.toString();
-    }
-
-    /**
-     * Handles value conversion of a literal expression based on its associated column.
-     *
-     * @param lhs LHS expression with which literal is associated with
-     * @param rhs RHS expression which needs value conversion if its a literal expression
-     * @return newly created literal {@link Expression} of rhs if converted else the same one.
-     */
-    private Expression handleValueConversionForLiteralExpression(Expression lhs, Expression rhs) {
-        if (!(lhs.getValueCase().equals(COLUMNIDENTIFIER) && rhs.getValueCase().equals(LITERAL))) {
-            return rhs;
-        }
-
-        Expression newRhs = rhs;
-        String lhsColumnName = lhs.getColumnIdentifier().getColumnName();
-
-        ToValueConverter converter = getValueConverter(rhs.getLiteral().getValue().getValueType());
-        if (converter != null) {
-            try {
-                Value value = converter.convert(rhs.getLiteral().getValue().getString(),
-                        viewDefinition.getColumnType(lhsColumnName));
-                newRhs = Expression.newBuilder()
-                        .setLiteral(LiteralConstant.newBuilder().setValue(value))
-                        .build();
-            } catch (Exception e) {
-                throw new IllegalArgumentException(
-                        String.format("Invalid string input:{ %s } for bytes column:{ %s }",
-                                rhs.getLiteral().getValue().getString(),
-                                viewDefinition.getPhysicalColumnNames(lhsColumnName).get(0)));
-            }
-        }
-
-        return newRhs;
-    }
-
-    private ToValueConverter getValueConverter(ValueType valueType) {
-        ToValueConverter result;
-        switch (valueType) {
-            case STRING:
-                result = StringToValueConverter.INSTANCE;
-                break;
-            default:
-                result = null;
-                break;
-        }
-        return result;
-    }
-
-    private String convertOperator2String(Operator operator) {
-        switch (operator) {
-            case AND:
-                return "AND";
-            case OR:
-                return "OR";
-            case NOT:
-                return "NOT";
-            case EQ:
-                return "=";
-            case NEQ:
-                return "!=";
-            case IN:
-                return "IN";
-            case NOT_IN:
-                return "NOT IN";
-            case GT:
-                return ">";
-            case LT:
-                return "<";
-            case GE:
-                return ">=";
-            case LE:
-                return "<=";
-            case LIKE:
-                return REGEX_OPERATOR;
-            case CONTAINS_KEY:
-            case CONTAINS_KEYVALUE:
-                return MAP_VALUE;
-            case RANGE:
-                throw new UnsupportedOperationException("RANGE NOT supported use >= and <=");
-            case UNRECOGNIZED:
-            default:
-                throw new UnsupportedOperationException("Unknown operator:" + operator);
-        }
-    }
-
-    private String convertExpression2String(Expression expression, Params.Builder paramsBuilder) {
-        switch (expression.getValueCase()) {
-            case COLUMNIDENTIFIER:
-                String logicalColumnName = expression.getColumnIdentifier().getColumnName();
-                // this takes care of the Map Type where it's split into 2 columns
-                List<String> columnNames = viewDefinition.getPhysicalColumnNames(logicalColumnName);
-                return joiner.join(columnNames);
-            case LITERAL:
-                return convertLiteralToString(expression.getLiteral(), paramsBuilder);
-            case FUNCTION:
-                Function function = expression.getFunction();
-                String functionName = function.getFunctionName();
-                // For COUNT(column_name), Pinot sql format converts it to COUNT(*) and even only works with
-                // COUNT(*) for ORDER BY
-                if (functionName.equalsIgnoreCase("COUNT")) {
-                    return functionName + "(*)";
-                }
-                List<Expression> argumentsList = function.getArgumentsList();
-                String[] args = new String[argumentsList.size()];
-                for (int i = 0; i < argumentsList.size(); i++) {
-                    Expression expr = argumentsList.get(i);
-                    args[i] = convertExpression2String(expr, paramsBuilder);
-                }
-                return functionName + "(" + joiner.join(args) + ")";
-            case ORDERBY:
-                OrderByExpression orderBy = expression.getOrderBy();
-                return convertExpression2String(orderBy.getExpression(), paramsBuilder);
-            case VALUE_NOT_SET:
-                break;
-        }
-        return "";
-    }
-
-    private String convertExpressionToMapKeyColumn(Expression expression) {
-        if (expression.getValueCase() == COLUMNIDENTIFIER) {
-            String logicalColumnName = expression.getColumnIdentifier().getColumnName();
-            String col = viewDefinition.getKeyColumnNameForMap(logicalColumnName);
-            if (col != null && col.length() > 0) {
-                return col;
-            }
-        }
-        throw new IllegalArgumentException(
-                "operator CONTAINS_KEY/KEYVALUE supports multi value column only");
-    }
-
-    private String convertExpressionToMapValueColumn(Expression expression) {
-        if (expression.getValueCase() == COLUMNIDENTIFIER) {
-            String logicalColumnName = expression.getColumnIdentifier().getColumnName();
-            String col = viewDefinition.getValueColumnNameForMap(logicalColumnName);
-            if (col != null && col.length() > 0) {
-                return col;
-            }
-        }
-        throw new IllegalArgumentException(
-                "operator CONTAINS_KEY/KEYVALUE supports multi value column only");
-    }
-
-    private LiteralConstant[] convertExpressionToMapLiterals(Expression expression) {
-        LiteralConstant[] literals = new LiteralConstant[2];
-        if (expression.getValueCase() == LITERAL) {
-            LiteralConstant value = expression.getLiteral();
-            if (value.getValue().getValueType() == ValueType.STRING_ARRAY) {
-                for (int i = 0; i < 2 && i < value.getValue().getStringArrayCount(); i++) {
-                    literals[i] =
-                            LiteralConstant.newBuilder()
-                                    .setValue(
-                                            Value.newBuilder().setString(value.getValue().getStringArray(i)).build())
-                                    .build();
-                }
-            } else {
-                throw new IllegalArgumentException(
-                        "operator CONTAINS_KEYVALUE supports "
-                                + ValueType.STRING_ARRAY.name()
-                                + " value type only");
-            }
-        }
-
-        for (int i = 0; i < literals.length; i++) {
-            if (literals[i] == null) {
-                literals[i] =
-                        LiteralConstant.newBuilder().setValue(Value.newBuilder().setString("").build()).build();
-            }
-        }
-
-        return literals;
-    }
-
-    /**
-     * TODO:Handle all types
-     */
-    private String convertLiteralToString(LiteralConstant literal, Params.Builder paramsBuilder) {
-        Value value = literal.getValue();
-        String ret = null;
-        switch (value.getValueType()) {
-            case STRING_ARRAY:
-                StringBuilder builder = new StringBuilder("(");
-                String delim = "";
-                for (String item : value.getStringArrayList()) {
-                    builder.append(delim);
-                    builder.append(QUESTION_MARK);
-                    paramsBuilder.addStringParam(item);
-                    delim = ", ";
-                }
-                builder.append(")");
-                ret = builder.toString();
-                break;
-            case LONG_ARRAY:
-                break;
-            case INT_ARRAY:
-                break;
-            case FLOAT_ARRAY:
-                break;
-            case DOUBLE_ARRAY:
-                break;
-            case BYTES_ARRAY:
-                break;
-            case BOOLEAN_ARRAY:
-                break;
-            case STRING:
-                ret = QUESTION_MARK;
-                paramsBuilder.addStringParam(value.getString());
-                break;
-            case LONG:
-                ret = QUESTION_MARK;
-                paramsBuilder.addLongParam(value.getLong());
-                break;
-            case INT:
-                ret = QUESTION_MARK;
-                paramsBuilder.addIntegerParam(value.getInt());
-                break;
-            case FLOAT:
-                ret = QUESTION_MARK;
-                paramsBuilder.addFloatParam(value.getFloat());
-                break;
-            case DOUBLE:
-                ret = QUESTION_MARK;
-                paramsBuilder.addDoubleParam(value.getDouble());
-                break;
-            case BYTES:
-                ret = QUESTION_MARK;
-                paramsBuilder.addBytesStringParam(Hex.encodeHexString(value.getBytes().toByteArray()));
-                break;
-            case BOOL:
-                ret = QUESTION_MARK;
-                paramsBuilder.addStringParam(String.valueOf(value.getBoolean()));
-                break;
-            case TIMESTAMP:
-                ret = QUESTION_MARK;
-                paramsBuilder.addLongParam(value.getTimestamp());
-                break;
-            case UNRECOGNIZED:
-                break;
-        }
-        return ret;
-    }
+    return ret;
+  }
 }

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/ViewDefinition.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/ViewDefinition.java
@@ -82,8 +82,8 @@ public class ViewDefinition {
     return (ValueType.STRING_MAP.equals(columnSpecMap.get(logicalName).getType()));
   }
 
-  public boolean isBytesColumn(String logicalName) {
-    return (ValueType.BYTES.equals(columnSpecMap.get(logicalName).getType()));
+  public ValueType getColumnType(String logicalName) {
+    return columnSpecMap.get(logicalName).getType();
   }
 
   public String getKeyColumnNameForMap(String logicalName) {

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/ViewDefinition.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/ViewDefinition.java
@@ -82,8 +82,8 @@ public class ViewDefinition {
     return (ValueType.STRING_MAP.equals(columnSpecMap.get(logicalName).getType()));
   }
 
-  public ValueType getColumnType(String logicalName) {
-    return columnSpecMap.get(logicalName).getType();
+  public boolean isBytesColumn(String logicalName) {
+    return (ValueType.BYTES.equals(columnSpecMap.get(logicalName).getType()));
   }
 
   public String getKeyColumnNameForMap(String logicalName) {

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/ViewDefinition.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/ViewDefinition.java
@@ -39,7 +39,7 @@ public class ViewDefinition {
 
     // get bytes fields
     final Set<String> bytesFields = new HashSet<>(
-        (List<String>) config.getOrDefault("bytesFields", new ArrayList<>()));
+        (List<String>) config.getOrDefault("bytesFields", List.of()));
 
     for (String logicalName : fieldMap.keySet()) {
       String physName = fieldMap.get(logicalName);

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/converters/StringToValueConverter.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/converters/StringToValueConverter.java
@@ -1,0 +1,38 @@
+package org.hypertrace.core.query.service.pinot.converters;
+
+import com.google.protobuf.ByteString;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.lang.StringUtils;
+import org.hypertrace.core.query.service.api.Value;
+import org.hypertrace.core.query.service.api.ValueType;
+
+/**
+ * Converter to convert any string value to requested {@link Value} of {@link ValueType}
+ * */
+public class StringToValueConverter implements ToValueConverter<String> {
+
+  public static final StringToValueConverter INSTANCE = new StringToValueConverter();
+  private static final String EMPTY = "";
+
+  private StringToValueConverter() {
+  }
+
+  public Value convert(String value, ValueType valueType) throws Exception {
+    Value.Builder valueBuilder = Value.newBuilder();
+    switch (valueType) {
+      case BYTES:
+        String outValue = (StringUtils.isEmpty(value) ||
+            value.equals("null") ||
+            value.equals("''")) ? EMPTY : value;
+        byte[] bytes = Hex.decodeHex(outValue);
+        valueBuilder.setBytes(ByteString.copyFrom(bytes));
+        valueBuilder.setValueType(ValueType.BYTES);
+        break;
+      default:
+        valueBuilder.setString(value);
+        valueBuilder.setValueType(ValueType.STRING);
+        break;
+    }
+    return valueBuilder.build();
+  }
+}

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/converters/ToValueConverter.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/converters/ToValueConverter.java
@@ -1,0 +1,12 @@
+package org.hypertrace.core.query.service.pinot.converters;
+
+import org.hypertrace.core.query.service.api.Value;
+import org.hypertrace.core.query.service.api.ValueType;
+
+/**
+ * An interface to convert an input type to requested {@link Value} based on {@link ValueType}.
+ */
+public interface ToValueConverter<T> {
+
+  Value convert(T value, ValueType valueType) throws Exception;
+}

--- a/query-service-impl/src/test/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverterTest.java
+++ b/query-service-impl/src/test/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverterTest.java
@@ -5,19 +5,16 @@ import static org.hypertrace.core.query.service.QueryRequestBuilderUtils.createF
 import static org.hypertrace.core.query.service.QueryRequestBuilderUtils.createOrderByExpression;
 import static org.mockito.ArgumentMatchers.any;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
-import java.util.HashMap;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.io.File;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 import org.apache.pinot.client.Connection;
 import org.apache.pinot.client.Request;
 import org.hypertrace.core.query.service.QueryContext;
-import org.hypertrace.core.query.service.RequestHandlerInfo;
-import org.hypertrace.core.query.service.RequestHandlerRegistry;
+import org.hypertrace.core.query.service.QueryServiceImplConfig.RequestHandlerConfig;
 import org.hypertrace.core.query.service.api.ColumnIdentifier;
 import org.hypertrace.core.query.service.api.Expression;
 import org.hypertrace.core.query.service.api.Filter;
@@ -40,8 +37,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 public class QueryRequestToPinotSQLConverterTest {
+
   private static final String TENANT_ID = "__default";
   private static final String TENANT_COLUMN_NAME = "tenant_id";
+
+  private static final String TEST_REQUEST_HANDLER_CONFIG_FILE = "request_handler.conf";
 
   private static ViewDefinition viewDefinition;
   private static QueryContext queryContext;
@@ -50,51 +50,14 @@ public class QueryRequestToPinotSQLConverterTest {
 
   @BeforeAll
   public static void setUp() {
-    String handlerName = "pinotBasedRequestHandler";
-
-    Map<String, Object> config = new HashMap<>();
-    Map<String, PinotColumnSpec> columnSpecMap = new HashMap<>();
-    Set<String> mapFields = Set.of("tags", "request_headers");
-
-    Map<String, List<String>> logicalToViewColumns =
-        ImmutableMap.<String, List<String>>builder()
-            .put("Span.tags", Lists.newArrayList("tags"))
-            .put("Span.id", Lists.newArrayList("span_id"))
-            .put("Span.duration_millis", Lists.newArrayList("duration_millis"))
-            .put("Span.start_time_millis", Lists.newArrayList("start_time_millis"))
-            .put("Span.end_time_millis", Lists.newArrayList("end_time_millis"))
-            .put("Span.displaySpanName", Lists.newArrayList("span_name"))
-            .put("Span.is_entry", Lists.newArrayList("is_entry"))
-            .put("Span.attributes.request_headers", Lists.newArrayList("request_headers"))
-            .put("Span.attributes.request_body", Lists.newArrayList("request_body"))
-            .put("Span.attributes.protocol_name", Lists.newArrayList("protocol_name"))
-            .put("Span.attributes.response_headers", Lists.newArrayList("response_headers"))
-            .put("Span.attributes.response_body", Lists.newArrayList("response_body"))
-            .put("Span.metrics.duration_millis", Lists.newArrayList("duration_millis"))
-            .put("Span.serviceName", Lists.newArrayList("service_name"))
-            .put("Span.attributes.parent_span_id", Lists.newArrayList("parent_span_id"))
-            .build();
-
-    for (String logicalName : logicalToViewColumns.keySet()) {
-      PinotColumnSpec spec = new PinotColumnSpec();
-      for (String viewName : logicalToViewColumns.get(logicalName)) {
-        if (mapFields.contains(viewName)) {
-          spec.setType(ValueType.STRING_MAP);
-          spec.addColumnName(viewName + "__KEYS");
-          spec.addColumnName(viewName + "__VALUES");
-        } else {
-          spec.addColumnName(viewName);
-          spec.setType(ValueType.STRING);
-        }
-      }
-      columnSpecMap.put(logicalName, spec);
-    }
-    viewDefinition = new ViewDefinition("SpanEventView", columnSpecMap, TENANT_COLUMN_NAME);
-    config.put(PinotBasedRequestHandler.VIEW_DEFINITION_CONFIG_KEY, viewDefinition);
-    RequestHandlerInfo requestHandlerInfo =
-        new RequestHandlerInfo(handlerName, PinotBasedRequestHandler.class, config);
-    RequestHandlerRegistry.get().register(handlerName, requestHandlerInfo);
-
+    Config fileConfig = ConfigFactory.parseFile(new File(
+        QueryRequestToPinotSQLConverterTest.class.getClassLoader()
+            .getResource(TEST_REQUEST_HANDLER_CONFIG_FILE)
+            .getFile()));
+    RequestHandlerConfig requestHandlerConfig = RequestHandlerConfig.parse(fileConfig);
+    viewDefinition = ViewDefinition.parse(
+        (Map<String, Object>) requestHandlerConfig.getRequestHandlerInfo().get("viewDefinition"),
+        TENANT_COLUMN_NAME);
     queryContext = new QueryContext(TENANT_ID);
   }
 
@@ -192,7 +155,8 @@ public class QueryRequestToPinotSQLConverterTest {
   @Test
   public void testQueryWithStringFilter() {
     QueryRequest queryRequest =
-        buildSimpleQueryWithFilter(createStringFilter("Span.displaySpanName", Operator.EQ, "GET /login"));
+        buildSimpleQueryWithFilter(
+            createStringFilter("Span.displaySpanName", Operator.EQ, "GET /login"));
     assertPQLQuery(
         queryRequest,
         "Select span_id FROM SpanEventView "
@@ -208,7 +172,8 @@ public class QueryRequestToPinotSQLConverterTest {
   public void testSQLiWithStringValueFilter() {
     QueryRequest queryRequest =
         buildSimpleQueryWithFilter(
-            createStringFilter("Span.displaySpanName", Operator.EQ, "GET /login' OR tenant_id = 'tenant2"));
+            createStringFilter("Span.displaySpanName", Operator.EQ,
+                "GET /login' OR tenant_id = 'tenant2"));
 
     assertPQLQuery(
         queryRequest,
@@ -596,6 +561,229 @@ public class QueryRequestToPinotSQLConverterTest {
             + "AND tags__keys = 'flags' and tags__values = '0' and mapvalue(tags__keys,'flags',tags__values) = '0'");
   }
 
+  @Test
+  public void testQueryWithBytesColumnWithValidId() {
+    Builder builder = QueryRequest.newBuilder();
+
+    // create selections
+    ColumnIdentifier spanId = ColumnIdentifier.newBuilder().setColumnName("Span.id").build();
+    builder.addSelection(Expression.newBuilder().setColumnIdentifier(spanId).build());
+
+    // create NEQ filter
+    Filter parentIdFilter = QueryRequestUtil
+        .createColumnValueFilter("Span.attributes.parent_span_id",
+            Operator.EQ, "042e5523ff6b2506").build();
+
+    Filter andFilter =
+        Filter.newBuilder()
+            .setOperator(Operator.AND)
+            .addChildFilter(parentIdFilter)
+            .build();
+    builder.setFilter(andFilter);
+    builder.setLimit(5);
+
+    QueryRequest request = builder.build();
+
+    assertPQLQuery(
+        request,
+        "SELECT span_id FROM SpanEventView "
+            + "WHERE "
+            + viewDefinition.getTenantIdColumn()
+            + " = '"
+            + TENANT_ID
+            + "' "
+            + "AND ( parent_span_id = '042e5523ff6b2506' ) limit 5");
+  }
+
+  @Test
+  public void testQueryWithBytesColumnWithInValidId() {
+    Builder builder = QueryRequest.newBuilder();
+
+    // create selections
+    ColumnIdentifier spanId = ColumnIdentifier.newBuilder().setColumnName("Span.id").build();
+    builder.addSelection(Expression.newBuilder().setColumnIdentifier(spanId).build());
+
+    // create NEQ filter
+    Filter parentIdFilter = QueryRequestUtil
+        .createColumnValueFilter("Span.attributes.parent_span_id",
+            Operator.EQ, "042e5523ff6b250L").build();
+
+    Filter andFilter =
+        Filter.newBuilder()
+            .setOperator(Operator.AND)
+            .addChildFilter(parentIdFilter)
+            .build();
+    builder.setFilter(andFilter);
+    builder.setLimit(5);
+
+    assertExceptionOnPQLQuery(builder.build(), IllegalArgumentException.class,
+        "Invalid string input:{ 042e5523ff6b250L } for bytes column:{ parent_span_id }");
+  }
+
+  @Test
+  public void testQueryWithBytesColumnWithNullId() {
+    Builder builder = QueryRequest.newBuilder();
+
+    // create selections
+    ColumnIdentifier spanId = ColumnIdentifier.newBuilder().setColumnName("Span.id").build();
+    builder.addSelection(Expression.newBuilder().setColumnIdentifier(spanId).build());
+
+    // create NEQ filter
+    Filter parentIdFilter = QueryRequestUtil
+        .createColumnValueFilter("Span.attributes.parent_span_id",
+            Operator.NEQ, "null").build();
+
+    Filter andFilter =
+        Filter.newBuilder()
+            .setOperator(Operator.AND)
+            .addChildFilter(parentIdFilter)
+            .build();
+    builder.setFilter(andFilter);
+    builder.setLimit(5);
+
+    QueryRequest request = builder.build();
+
+    assertPQLQuery(
+        request,
+        "SELECT span_id FROM SpanEventView "
+            + "WHERE "
+            + viewDefinition.getTenantIdColumn()
+            + " = '"
+            + TENANT_ID
+            + "' "
+            + "AND ( parent_span_id != '' ) limit 5");
+  }
+
+  @Test
+  public void testQueryWithBytesColumnWithEmptyId() {
+    Builder builder = QueryRequest.newBuilder();
+
+    // create selections
+    ColumnIdentifier spanId = ColumnIdentifier.newBuilder().setColumnName("Span.id").build();
+    builder.addSelection(Expression.newBuilder().setColumnIdentifier(spanId).build());
+
+    // create NEQ filter
+    Filter parentIdFilter = QueryRequestUtil
+        .createColumnValueFilter("Span.attributes.parent_span_id",
+            Operator.NEQ, "''").build();
+
+    Filter andFilter =
+        Filter.newBuilder()
+            .setOperator(Operator.AND)
+            .addChildFilter(parentIdFilter)
+            .build();
+    builder.setFilter(andFilter);
+    builder.setLimit(5);
+
+    QueryRequest request = builder.build();
+
+    assertPQLQuery(
+        request,
+        "SELECT span_id FROM SpanEventView "
+            + "WHERE "
+            + viewDefinition.getTenantIdColumn()
+            + " = '"
+            + TENANT_ID
+            + "' "
+            + "AND ( parent_span_id != '' ) limit 5");
+  }
+
+  @Test
+  public void testQueryWithBytesColumnWithLikeFilter() {
+    Builder builder = QueryRequest.newBuilder();
+    ColumnIdentifier spanId = ColumnIdentifier.newBuilder().setColumnName("Span.id").build();
+    builder.addSelection(Expression.newBuilder().setColumnIdentifier(spanId).build());
+
+    ColumnIdentifier parentSpanId = ColumnIdentifier.newBuilder()
+        .setColumnName("Span.attributes.parent_span_id").build();
+    Filter likeFilter =
+        Filter.newBuilder()
+            .setOperator(Operator.LIKE)
+            .setLhs(Expression.newBuilder().setColumnIdentifier(parentSpanId).build())
+            .setRhs(
+                Expression.newBuilder()
+                    .setLiteral(
+                        LiteralConstant.newBuilder()
+                            .setValue(Value.newBuilder().setString("null").build()))
+                    .build())
+            .build();
+
+    builder.setFilter(likeFilter);
+    assertPQLQuery(
+        builder.build(),
+        "SELECT span_id FROM SpanEventView "
+            + "WHERE "
+            + viewDefinition.getTenantIdColumn()
+            + " = '"
+            + TENANT_ID
+            + "' "
+            + "AND REGEXP_LIKE(parent_span_id,'')");
+  }
+
+  @Test
+  public void testQueryWithStringColumnWithNullString() {
+    Builder builder = QueryRequest.newBuilder();
+
+    // create selections
+    ColumnIdentifier spanId = ColumnIdentifier.newBuilder().setColumnName("Span.id").build();
+    builder.addSelection(Expression.newBuilder().setColumnIdentifier(spanId).build());
+
+    // create NEQ filter
+    Filter parentIdFilter = QueryRequestUtil
+        .createColumnValueFilter("Span.id",
+            Operator.NEQ, "null").build();
+
+    Filter andFilter =
+        Filter.newBuilder()
+            .setOperator(Operator.AND)
+            .addChildFilter(parentIdFilter)
+            .build();
+    builder.setFilter(andFilter);
+    builder.setLimit(5);
+
+    QueryRequest request = builder.build();
+
+    assertPQLQuery(
+        request,
+        "SELECT span_id FROM SpanEventView "
+            + "WHERE "
+            + viewDefinition.getTenantIdColumn()
+            + " = '"
+            + TENANT_ID
+            + "' "
+            + "AND ( span_id != 'null' ) limit 5");
+  }
+
+  @Test
+  public void testQueryWithStringColumnWithNullStringWithLikeFilter() {
+    Builder builder = QueryRequest.newBuilder();
+    ColumnIdentifier spanId = ColumnIdentifier.newBuilder().setColumnName("Span.id").build();
+    builder.addSelection(Expression.newBuilder().setColumnIdentifier(spanId).build());
+
+    Filter likeFilter =
+        Filter.newBuilder()
+            .setOperator(Operator.LIKE)
+            .setLhs(Expression.newBuilder().setColumnIdentifier(spanId).build())
+            .setRhs(
+                Expression.newBuilder()
+                    .setLiteral(
+                        LiteralConstant.newBuilder()
+                            .setValue(Value.newBuilder().setString("null").build()))
+                    .build())
+            .build();
+
+    builder.setFilter(likeFilter);
+    assertPQLQuery(
+        builder.build(),
+        "SELECT span_id FROM SpanEventView "
+            + "WHERE "
+            + viewDefinition.getTenantIdColumn()
+            + " = '"
+            + TENANT_ID
+            + "' "
+            + "AND REGEXP_LIKE(span_id,'null')");
+  }
+
   private Filter createTimeFilter(String columnName, Operator op, long value) {
     ColumnIdentifier startTimeColumn =
         ColumnIdentifier.newBuilder().setColumnName(columnName).build();
@@ -745,7 +933,8 @@ public class QueryRequestToPinotSQLConverterTest {
                 ColumnIdentifier.newBuilder().setColumnName("Span.serviceName").build()));
     builder.addGroupBy(
         Expression.newBuilder()
-            .setColumnIdentifier(ColumnIdentifier.newBuilder().setColumnName("Span.displaySpanName").build()));
+            .setColumnIdentifier(
+                ColumnIdentifier.newBuilder().setColumnName("Span.displaySpanName").build()));
     return builder.build();
   }
 
@@ -779,7 +968,8 @@ public class QueryRequestToPinotSQLConverterTest {
                 ColumnIdentifier.newBuilder().setColumnName("Span.serviceName").build()));
     builder.addGroupBy(
         Expression.newBuilder()
-            .setColumnIdentifier(ColumnIdentifier.newBuilder().setColumnName("Span.displaySpanName").build()));
+            .setColumnIdentifier(
+                ColumnIdentifier.newBuilder().setColumnName("Span.displaySpanName").build()));
 
     builder.addOrderBy(
         createOrderByExpression(createColumnExpression("Span.serviceName"), SortOrder.ASC));
@@ -813,6 +1003,17 @@ public class QueryRequestToPinotSQLConverterTest {
     Mockito.verify(connection, Mockito.times(1)).execute(statementCaptor.capture());
     Assertions.assertEquals(
         expectedQuery.toLowerCase(), statementCaptor.getValue().getQuery().toLowerCase());
+  }
+
+  private void assertExceptionOnPQLQuery(QueryRequest queryRequest, Class className,
+      String expectedMessage) {
+    QueryRequestToPinotSQLConverter converter = new QueryRequestToPinotSQLConverter(viewDefinition);
+
+    Throwable exception = Assertions.assertThrows(className, () -> converter
+        .toSQL(queryContext, queryRequest, createSelectionsFromQueryRequest(queryRequest)));
+
+    String actualMessage = exception.getMessage();
+    Assertions.assertTrue(actualMessage.contains(expectedMessage));
   }
 
   // This method will put the selections in a LinkedHashSet in the order that RequestAnalyzer does:

--- a/query-service-impl/src/test/resources/request_handler.conf
+++ b/query-service-impl/src/test/resources/request_handler.conf
@@ -1,0 +1,29 @@
+{
+  name = piontCluster0
+  type = pinot
+  clientConfig = broker
+  requestHandlerInfo = {
+    viewDefinition = {
+      viewName = SpanEventView
+      mapFields = ["tags", "request_headers"]
+      bytesFields = ["parent_span_id"]
+      fieldMap = {
+        "Span.tags": "tags",
+        "Span.id": "span_id",
+        "Span.duration_millis": "duration_millis",
+        "Span.start_time_millis": "start_time_millis",
+        "Span.end_time_millis": "end_time_millis",
+        "Span.displaySpanName": "span_name",
+        "Span.is_entry": "is_entry",
+        "Span.attributes.request_headers": "request_headers",
+        "Span.attributes.request_body": "request_body"
+        "Span.attributes.protocol_name": "protocol_name",
+        "Span.attributes.response_headers": "response_headers",
+        "Span.attributes.response_body": "response_body",
+        "Span.metrics.duration_millis": "duration_millis",
+        "Span.serviceName": "service_name",
+        "Span.attributes.parent_span_id": "parent_span_id"
+      }
+    }
+  }
+}

--- a/query-service/src/main/resources/configs/common/application.conf
+++ b/query-service/src/main/resources/configs/common/application.conf
@@ -41,7 +41,7 @@ service.config = {
         viewDefinition = {
           viewName = spanEventView
           mapFields = ["tags"]
-          bytesFields = ["span_id", "trace_id", "api_trace_id", "parent_span_id"]
+          bytesFields = ["span_id", "api_trace_id", "trace_id", "parent_span_id"]
           fieldMap = {
             "EVENT.serviceId": "service_id",
             "EVENT.serviceName" : "service_name",
@@ -75,6 +75,7 @@ service.config = {
       requestHandlerInfo = {
         viewDefinition = {
           viewName = rawServiceView
+          bytesFields = ["span_id", "trace_id"]
           fieldMap = {
             "SERVICE.startTime": "start_time_millis",
             "SERVICE.endTime": "end_time_millis",
@@ -100,7 +101,7 @@ service.config = {
         viewDefinition = {
           viewName = spanEventView
           mapFields = ["tags", "request_headers", "request_params", "response_headers"]
-          bytesFields = ["trace_id", "api_trace_id"]
+          bytesFields = ["span_id", "api_trace_id", "trace_id", "parent_span_id"]
           fieldMap = {
             "API_TRACE.apiName" : "api_name",
             "API_TRACE.apiId" : "api_id",
@@ -148,7 +149,7 @@ service.config = {
         viewDefinition = {
           viewName = backendEntityView
           mapFields = ["tags", "request_headers", "request_params", "response_headers"]
-          bytesFields = ["trace_id"]
+          bytesFields = ["span_id", "trace_id"]
           fieldMap = {
             "BACKEND_TRACE.backendTraceId" : "backend_trace_id",
             "BACKEND_TRACE.traceId" : "trace_id",
@@ -178,6 +179,7 @@ service.config = {
       requestHandlerInfo = {
         viewDefinition = {
           viewName = serviceCallView
+          bytesFields = ["trace_id", "server_event_id", "client_event_id"]
           fieldMap = {
             "INTERACTION.startTime": "start_time_millis",
             "INTERACTION.endTime": "end_time_millis",
@@ -200,6 +202,7 @@ service.config = {
       requestHandlerInfo = {
         viewDefinition = {
           viewName = backendEntityView
+          bytesFields = ["span_id", "trace_id"]
           fieldMap = {
             "BACKEND.startTime": "start_time_millis",
             "BACKEND.endTime": "end_time_millis",
@@ -224,6 +227,7 @@ service.config = {
       requestHandlerInfo = {
         viewDefinition = {
           viewName = rawServiceView
+          bytesFields = ["span_id", "trace_id"]
           fieldMap = {
             "API.startTime": "start_time_millis",
             "API.endTime": "end_time_millis",

--- a/query-service/src/main/resources/configs/common/application.conf
+++ b/query-service/src/main/resources/configs/common/application.conf
@@ -18,6 +18,7 @@ service.config = {
       requestHandlerInfo = {
         viewDefinition = {
           viewName = rawTraceView
+          bytesFields = ["trace_id"]
           fieldMap = {
             "TRACE.id": "trace_id",
             "TRACE.startTime": "start_time_millis",
@@ -37,6 +38,7 @@ service.config = {
         viewDefinition = {
           viewName = spanEventView
           mapFields = ["tags"]
+          bytesFields = ["span_id", "trace_id", "parent_span_id"]
           fieldMap = {
             "EVENT.serviceName": "service_name",
             "EVENT.id": "span_id",

--- a/query-service/src/main/resources/configs/common/application.conf
+++ b/query-service/src/main/resources/configs/common/application.conf
@@ -41,7 +41,7 @@ service.config = {
         viewDefinition = {
           viewName = spanEventView
           mapFields = ["tags"]
-          bytesFields = ["span_id", "trace_id", "parent_span_id"]
+          bytesFields = ["span_id", "trace_id", "api_trace_id", "parent_span_id"]
           fieldMap = {
             "EVENT.serviceId": "service_id",
             "EVENT.serviceName" : "service_name",
@@ -100,6 +100,7 @@ service.config = {
         viewDefinition = {
           viewName = spanEventView
           mapFields = ["tags", "request_headers", "request_params", "response_headers"]
+          bytesFields = ["trace_id", "api_trace_id"]
           fieldMap = {
             "API_TRACE.apiName" : "api_name",
             "API_TRACE.apiId" : "api_id",
@@ -147,6 +148,7 @@ service.config = {
         viewDefinition = {
           viewName = backendEntityView
           mapFields = ["tags", "request_headers", "request_params", "response_headers"]
+          bytesFields = ["trace_id"]
           fieldMap = {
             "BACKEND_TRACE.backendTraceId" : "backend_trace_id",
             "BACKEND_TRACE.traceId" : "trace_id",


### PR DESCRIPTION
There are few strings IDs fields are maps to bytes column in pinot, as part of this PR,
- adds support for handling filtering query on such fields by type conversion (e.g parent_span_id != 'null')
- fails fast on invalid string input for such fields if it fails to convert to valid hex string
- re-factored init steps for pinot query conversion tests