### PR TITLE
Handling the empty bracket scenario for bytes filter

### DIFF
--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/converters/StringToValueConverter.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/converters/StringToValueConverter.java
@@ -21,9 +21,9 @@ public class StringToValueConverter implements ToValueConverter<String> {
     Value.Builder valueBuilder = Value.newBuilder();
     switch (valueType) {
       case BYTES:
-        String outValue = (StringUtils.isEmpty(value) ||
-            value.equals("null") ||
-            value.equals("''")) ? EMPTY : value;
+        String trimmed = StringUtils.trim(value);
+        String outValue = (StringUtils.isEmpty(trimmed) || trimmed.equals("null") ||
+                trimmed.equals("''")) || trimmed.equals("{}")? EMPTY : value;
         byte[] bytes = Hex.decodeHex(outValue);
         valueBuilder.setBytes(ByteString.copyFrom(bytes));
         valueBuilder.setValueType(ValueType.BYTES);

--- a/query-service-impl/src/test/java/org/hypertrace/core/query/service/pinot/StringToValueConverterTest.java
+++ b/query-service-impl/src/test/java/org/hypertrace/core/query/service/pinot/StringToValueConverterTest.java
@@ -1,0 +1,45 @@
+package org.hypertrace.core.query.service.pinot;
+
+import com.google.protobuf.ByteString;
+import org.apache.commons.codec.DecoderException;
+import org.hypertrace.core.query.service.api.Value;
+import org.hypertrace.core.query.service.api.ValueType;
+import org.hypertrace.core.query.service.pinot.converters.StringToValueConverter;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class StringToValueConverterTest {
+
+  @Test
+  public void testValidNullFieldsForBytesColumn() throws Exception {
+    StringToValueConverter instance = StringToValueConverter.INSTANCE;
+
+    Value value = instance.convert("", ValueType.BYTES);
+    Assertions.assertNotNull(value);
+    Assertions.assertEquals(ValueType.BYTES, value.getValueType());
+    Assertions.assertEquals(ByteString.EMPTY, value.getBytes());
+
+    value = instance.convert("null", ValueType.BYTES);
+    Assertions.assertNotNull(value);
+    Assertions.assertEquals(ValueType.BYTES, value.getValueType());
+    Assertions.assertEquals(ByteString.EMPTY, value.getBytes());
+
+    value = instance.convert("''", ValueType.BYTES);
+    Assertions.assertNotNull(value);
+    Assertions.assertEquals(ValueType.BYTES, value.getValueType());
+    Assertions.assertEquals(ByteString.EMPTY, value.getBytes());
+
+    value = instance.convert("{}", ValueType.BYTES);
+    Assertions.assertNotNull(value);
+    Assertions.assertEquals(ValueType.BYTES, value.getValueType());
+    Assertions.assertEquals(ByteString.EMPTY, value.getBytes());
+  }
+
+  @Test
+  public void testInValidNullFieldsForBytesColumn() {
+    StringToValueConverter instance = StringToValueConverter.INSTANCE;
+    Assertions.assertThrows(DecoderException.class, () -> {
+      Value value = instance.convert("abc", ValueType.BYTES);
+    });
+  }
+}


### PR DESCRIPTION
This PR handles the filter scenario for bytes type,

```
childFilter {
    childFilter {
      lhs {
        columnIdentifier {
          columnName: "EVENT.id"
        }
      }
      operator: EQ
      rhs {
        literal {
          value {
            string: "{}"
          }
        }
      }
    }
  }
      }
```

It adds '{}' as a valid list of null values for bytes field