### PR TITLE
chore: fix snyk failures

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,9 +5,9 @@ ignore:
   SNYK-JAVA-LOG4J-572732:
     - '*':
         reason: no available replacement
-        expires: 2020-10-31T00:00:00.000Z
+        expires: 2021-01-31T00:00:00.000Z
   SNYK-JAVA-IONETTY-473694:
     - '*':
         reason: no available replacement
-        expires: 2020-10-31T00:00:00.000Z
+        expires: 2021-01-31T00:00:00.000Z
 patch: {}

--- a/query-service-impl/build.gradle.kts
+++ b/query-service-impl/build.gradle.kts
@@ -14,11 +14,11 @@ dependencies {
       because("Deserialization of Untrusted Data [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-561587] in com.fasterxml.jackson.core:jackson-databind@2.9.8\n" +
           "   used by org.apache.pinot:pinot-java-client")
     }
-    implementation("io.netty:netty:3.10.3.Final") {
+    implementation("io.netty:netty:3.10.6.Final") {
       because("HTTP Request Smuggling [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-IONETTY-473694] in io.netty:netty@3.9.6.Final\n" +
           "    introduced by org.apache.pinot:pinot-java-client")
     }
-    implementation("org.apache.zookeeper:zookeeper:3.6.1") {
+    implementation("org.apache.zookeeper:zookeeper:3.6.2") {
       because("Authentication Bypass [High Severity][https://snyk.io/vuln/SNYK-JAVA-ORGAPACHEZOOKEEPER-32301] in org.apache.zookeeper:zookeeper@3.4.6\n" +
           "    introduced by org.apache.pinot:pinot-java-client")
     }


### PR DESCRIPTION
## Description
Fixes for vulnerabilities still not available even in the latest versions of io netty and zookeeper dependencies.

Failure in build:
```
Issues with no direct upgrade or patch:
  ✗ HTTP Request Smuggling [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-IONETTY-473694] in io.netty:netty@3.10.3.Final
    introduced by org.apache.pinot:pinot-java-client@0.5.0 > io.netty:netty@3.10.3.Final
  No upgrade or patch available
  ✗ Deserialization of Untrusted Data [High Severity][https://snyk.io/vuln/SNYK-JAVA-LOG4J-572732] in log4j:log4j@1.2.17
    introduced by org.apache.zookeeper:zookeeper@3.6.1 > log4j:log4j@1.2.17 and 1 other path(s)
  No upgrade or patch available
```