### PR TITLE
ci: handles github actions repo name change

### DIFF
--- a/.github/workflows/merge-publish.yml
+++ b/.github/workflows/merge-publish.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
       
       - name: create checksum file
-        uses: hypertrace/actions/checksum@main
+        uses: hypertrace/github-actions/checksum@main
 
       - name: Cache packages
         uses: actions/cache@v2
@@ -36,7 +36,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_READ_TOKEN }}
 
       - name: push docker image
-        uses: hypertrace/actions/gradle@main
+        uses: hypertrace/github-actions/gradle@main
         with: 
           args: dockerPushImages
         env:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       
       - name: create checksum file
-        uses: hypertrace/actions/checksum@main
+        uses: hypertrace/github-actions/checksum@main
 
       - name: Cache packages
         uses: actions/cache@v2
@@ -38,7 +38,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_READ_TOKEN }}
       
       - name: Build with Gradle
-        uses: hypertrace/actions/gradle@main
+        uses: hypertrace/github-actions/gradle@main
         with: 
           args: build dockerBuildImages
 
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 0
 
       - name: validate charts
-        uses: hypertrace/actions/validate-charts@main
+        uses: hypertrace/github-actions/validate-charts@main
 
   snyk-scan:
     runs-on: ubuntu-20.04

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
       
       - name: create checksum file
-        uses: hypertrace/actions/checksum@main
+        uses: hypertrace/github-actions/checksum@main
 
       - name: Cache packages
         uses: actions/cache@v2
@@ -29,7 +29,7 @@ jobs:
 
 
       - name: Unit test
-        uses: hypertrace/actions/gradle@main
+        uses: hypertrace/github-actions/gradle@main
         with: 
           args: jacocoTestReport
 
@@ -41,7 +41,7 @@ jobs:
           flags: unit
 
       - name: copy test reports
-        uses: hypertrace/actions/gradle@main
+        uses: hypertrace/github-actions/gradle@main
         with: 
           args: copyAllReports --output-dir=/tmp/test-reports
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: create checksum file
-        uses: hypertrace/actions/checksum@main
+        uses: hypertrace/github-actions/checksum@main
 
       - name: Cache packages
         uses: actions/cache@v2
@@ -35,7 +35,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_READ_TOKEN }}
 
       - name: publish docker image
-        uses: hypertrace/actions/gradle@main
+        uses: hypertrace/github-actions/gradle@main
         with: 
           args: publish dockerPushImages
         env:
@@ -55,7 +55,7 @@ jobs:
           fetch-depth: 0
    
       - name: package and release charts
-        uses: hypertrace/actions/helm-gcs-publish@main
+        uses: hypertrace/github-actions/helm-gcs-publish@main
         with: 
           helm-gcs-credentials: ${{ secrets.HELM_GCS_CREDENTIALS }}
           helm-gcs-repository: ${{ secrets.HELM_GCS_REPOSITORY }}


### PR DESCRIPTION
## Description
To remove ambiguity, we have decided to keep our GitHub customs actions in a repo named `hypertrace/github-actions` (https://github.com/hypertrace/github-actions) instead of `hypertrace/actions` (https://github.com/hypertrace/actions) and this PR will solve any failures that might happen after deletion of `hypertrace/actions` repo. 


### Testing
Already merged here: https://github.com/hypertrace/attribute-service/pull/66

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

