### PR TITLE
feat: adding backend_operation field in query service config

### DIFF
--- a/query-service/src/main/resources/configs/common/application.conf
+++ b/query-service/src/main/resources/configs/common/application.conf
@@ -186,6 +186,7 @@ service.config = {
             "BACKEND_TRACE.statusMessage" : "status_message",
             "BACKEND_TRACE.tags" : "tags",
             "BACKEND_TRACE.spaceIds": "space_ids"
+            "BACKEND_TRACE.operation": "backend_operation"
           }
         }
       }

--- a/query-service/src/main/resources/configs/common/application.conf
+++ b/query-service/src/main/resources/configs/common/application.conf
@@ -186,7 +186,7 @@ service.config = {
             "BACKEND_TRACE.statusMessage" : "status_message",
             "BACKEND_TRACE.tags" : "tags",
             "BACKEND_TRACE.spaceIds": "space_ids"
-            "BACKEND_TRACE.operation": "backend_operation"
+            "BACKEND_TRACE.backendOperation": "backend_operation"
           }
         }
       }

--- a/query-service/src/main/resources/configs/common/application.conf
+++ b/query-service/src/main/resources/configs/common/application.conf
@@ -186,7 +186,7 @@ service.config = {
             "BACKEND_TRACE.statusMessage" : "status_message",
             "BACKEND_TRACE.tags" : "tags",
             "BACKEND_TRACE.spaceIds": "space_ids"
-            "BACKEND_TRACE.backendOperation": "backend_operation"
+            "BACKEND_TRACE.operation": "backend_operation"
           }
         }
       }


### PR DESCRIPTION
## Description
Adding backend_operation field in query-service config as we are working on adding Operation column in Backend Trace (call) view.


### Testing
NA

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
