### PR TITLE
fix: ignore materialized projections

### DIFF
--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/projection/ProjectionTransformation.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/projection/ProjectionTransformation.java
@@ -142,6 +142,9 @@ final class ProjectionTransformation implements QueryTransformation {
     if (!attributeMetadata.getDefinition().hasProjection()) {
       return Maybe.empty();
     }
+    if (attributeMetadata.getMaterialized()) {
+      return Maybe.empty();
+    }
     return this.rewriteProjectionAsQueryExpression(
             attributeMetadata.getDefinition().getProjection(), attributeMetadata.getValueKind())
         .toMaybe();


### PR DESCRIPTION
## Description
When projecting attributes, sometimes we write those projections into pinot for query performance. In those cases, the query should not be transformed - this change reads the materialized flag off the attribute definition to decide whether to proceed with transformation.

### Testing
Ran E2E, updated UTs

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

