### PR TITLE
chore: adds api_trace_error_span_count attribute

### DIFF
--- a/query-service/src/main/resources/configs/common/application.conf
+++ b/query-service/src/main/resources/configs/common/application.conf
@@ -158,7 +158,8 @@ service.config = {
             "API_TRACE.userScore" : "user_score",
             "API_TRACE.spaceIds": "space_ids",
             "API_TRACE.apiExitCalls": "api_exit_calls",
-            "API_TRACE.apiCalleeNameCount" : "api_callee_name_count"
+            "API_TRACE.apiCalleeNameCount" : "api_callee_name_count",
+            "API_TRACE.apiTraceErrorSpanCount": "api_trace_error_span_count"
           }
         }
       }


### PR DESCRIPTION
## Description
Adds api_trace_error_count attribute as per changes here: hypertrace/hypertrace-ingester#172

### Testing
NA

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation

