### PR TITLE
chore: use newer attribute client with lazy errors

### DIFF
--- a/query-service-impl/build.gradle.kts
+++ b/query-service-impl/build.gradle.kts
@@ -31,9 +31,9 @@ dependencies {
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.4.0")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.4.0")
   implementation("org.hypertrace.core.grpcutils:grpc-server-rx-utils:0.4.0")
-  implementation("org.hypertrace.core.attribute.service:attribute-service-api:0.12.0")
-  implementation("org.hypertrace.core.attribute.service:attribute-projection-registry:0.12.0")
-  implementation("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.12.0")
+  implementation("org.hypertrace.core.attribute.service:attribute-service-api:0.12.3")
+  implementation("org.hypertrace.core.attribute.service:attribute-projection-registry:0.12.3")
+  implementation("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.12.3")
   implementation("org.hypertrace.core.serviceframework:service-framework-spi:0.1.23")
   implementation("com.google.inject:guice:5.0.1")
   implementation("org.apache.pinot:pinot-java-client:0.6.0") {

--- a/query-service/build.gradle.kts
+++ b/query-service/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
   integrationTestImplementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-serdes:0.1.13")
 
   integrationTestImplementation(project(":query-service-client"))
-  integrationTestImplementation("org.hypertrace.core.attribute.service:attribute-service-client:0.12.0")
+  integrationTestImplementation("org.hypertrace.core.attribute.service:attribute-service-client:0.12.3")
 }
 
 application {


### PR DESCRIPTION
## Description
Use newer attribute client with better performing client (builds errors lazily, less exception filling)