### PR TITLE
ci: update codecov

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -33,10 +33,9 @@ jobs:
           args: jacocoTestReport
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           name: unit test reports
-          fail_ci_if_error: true
           flags: unit
 
       - name: Integration test
@@ -45,10 +44,9 @@ jobs:
           args: jacocoIntegrationTestReport
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           name: integration test reports
-          fail_ci_if_error: true
           flags: integration
 
       - name: copy test reports


### PR DESCRIPTION
## Description
Codecov bash uploader is being deprecated and is currently in the brownout phase. We need to upgrade to the v2 gh action in all repos.

More info: https://about.codecov.io/blog/codecov-uploader-deprecation-plan/