### PR TITLE
chore: include execution stats when logging slow query warn message

### DIFF
--- a/query-service-api/build.gradle.kts
+++ b/query-service-api/build.gradle.kts
@@ -72,5 +72,5 @@ dependencies {
   api("javax.annotation:javax.annotation-api:1.3.2")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
-  testImplementation("com.google.protobuf:protobuf-java-util:3.15.6")
+  testImplementation("com.google.protobuf:protobuf-java-util:3.19.2")
 }

--- a/query-service-api/build.gradle.kts
+++ b/query-service-api/build.gradle.kts
@@ -16,7 +16,7 @@ val generateLocalGoGrpcFiles = false
 
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:3.15.6"
+    artifact = "com.google.protobuf:protoc:3.19.2"
   }
   plugins {
     // Optional: an artifact spec for a protoc plugin, with "grpc" as

--- a/query-service-impl/build.gradle.kts
+++ b/query-service-impl/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
   implementation("org.slf4j:slf4j-api:1.7.32")
   implementation("commons-codec:commons-codec:1.15")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.33")
-  implementation("com.google.protobuf:protobuf-java-util:3.15.6")
+  implementation("com.google.protobuf:protobuf-java-util:3.19.2")
   implementation("com.google.guava:guava:30.1.1-jre")
   implementation("io.reactivex.rxjava3:rxjava:3.0.11")
   implementation("com.squareup.okhttp3:okhttp:4.9.1")

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/PinotBasedRequestHandler.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/PinotBasedRequestHandler.java
@@ -416,10 +416,11 @@ public class PinotBasedRequestHandler implements RequestHandler {
                 if (requestTimeMs > slowQueryThreshold) {
                   try {
                     LOG.warn(
-                        "Query Execution time: {} ms, sqlQuery: {}, queryRequest: {}",
+                        "Query Execution time: {} ms, sqlQuery: {}, queryRequest: {}, executionStats: {}",
                         requestTimeMs,
                         pql.getKey(),
-                        protoJsonPrinter.print(request));
+                        protoJsonPrinter.print(request),
+                        resultSetGroup.getExecutionStats());
                   } catch (InvalidProtocolBufferException ignore) {
                   }
                 }

--- a/query-service/build.gradle.kts
+++ b/query-service/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
 
   runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1")
   runtimeOnly("io.grpc:grpc-netty")
-  integrationTestImplementation("com.google.protobuf:protobuf-java-util:3.17.3")
+  integrationTestImplementation("com.google.protobuf:protobuf-java-util:3.19.2")
   integrationTestImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   integrationTestImplementation("org.testcontainers:testcontainers:1.16.2")
   integrationTestImplementation("org.testcontainers:junit-jupiter:1.16.2")


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
