### PR TITLE
feat: add configurable limit validation

### DIFF
--- a/helm/templates/query-service-config.yaml
+++ b/helm/templates/query-service-config.yaml
@@ -12,6 +12,11 @@ data:
         host = {{ .Values.queryServiceConfig.data.attributeClient.host }}
         port = {{ .Values.queryServiceConfig.data.attributeClient.port }}
       }
+      validation.limit = {
+        min = {{ .Values.queryServiceConfig.data.validation.limit.min }}
+        max = {{ .Values.queryServiceConfig.data.validation.limit.max }}
+        mode = {{ .Values.queryServiceConfig.data.validation.limit.mode }}
+      }
       clients = [
         {
           type = zookeeper

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -69,6 +69,11 @@ queryServiceConfig:
     attributeClient:
       host: attribute-service
       port: 9012
+    validation:
+      limit:
+        min: 1
+        max: 10000
+        mode: WARN
 handlers: []
 
 extraHandlers: []

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/QueryServiceConfig.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/QueryServiceConfig.java
@@ -3,16 +3,22 @@ package org.hypertrace.core.query.service;
 import com.typesafe.config.Config;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.Value;
+import lombok.experimental.NonFinal;
 
+@Value
+@NonFinal
 public class QueryServiceConfig {
 
   private static final String CONFIG_PATH_HANDLER_CLIENT_LIST = "clients";
   private static final String CONFIG_PATH_HANDLER_CONFIG_LIST = "queryRequestHandlersConfig";
   private static final String CONFIG_PATH_ATTRIBUTE_CLIENT = "attribute.client";
+  private static final String CONFIG_PATH_LIMIT_VALIDATION = "validation.limit";
 
-  private final List<RequestHandlerClientConfig> requestHandlerClientConfigs;
-  private final List<RequestHandlerConfig> queryRequestHandlersConfigs;
-  private final ClientHostPortConfig attributeClientConfig;
+  List<RequestHandlerClientConfig> requestHandlerClientConfigs;
+  List<RequestHandlerConfig> queryRequestHandlersConfigs;
+  ClientHostPortConfig attributeClientConfig;
+  LimitValidationConfig limitValidationConfig;
 
   QueryServiceConfig(Config config) {
     Config resolved = config.resolve();
@@ -26,30 +32,22 @@ public class QueryServiceConfig {
         resolved.getConfigList(CONFIG_PATH_HANDLER_CONFIG_LIST).stream()
             .map(RequestHandlerConfig::new)
             .collect(Collectors.toUnmodifiableList());
+    this.limitValidationConfig =
+        new LimitValidationConfig(resolved.getConfig(CONFIG_PATH_LIMIT_VALIDATION));
   }
 
-  public List<RequestHandlerClientConfig> getRequestHandlerClientConfigs() {
-    return this.requestHandlerClientConfigs;
-  }
-
-  public List<RequestHandlerConfig> getQueryRequestHandlersConfigs() {
-    return this.queryRequestHandlersConfigs;
-  }
-
-  public ClientHostPortConfig getAttributeClientConfig() {
-    return this.attributeClientConfig;
-  }
-
+  @Value
+  @NonFinal
   public static class RequestHandlerConfig {
     private static final String CONFIG_PATH_NAME = "name";
     private static final String CONFIG_PATH_TYPE = "type";
     private static final String CONFIG_PATH_CLIENT_KEY = "clientConfig";
     private static final String CONFIG_PATH_REQUEST_HANDLER_INFO = "requestHandlerInfo";
 
-    private final String name;
-    private final String type;
-    private final String clientConfig;
-    private final Config requestHandlerInfo;
+    String name;
+    String type;
+    String clientConfig;
+    Config requestHandlerInfo;
 
     private RequestHandlerConfig(Config config) {
       this.name = config.getString(CONFIG_PATH_NAME);
@@ -57,61 +55,56 @@ public class QueryServiceConfig {
       this.clientConfig = config.getString(CONFIG_PATH_CLIENT_KEY);
       this.requestHandlerInfo = config.getConfig(CONFIG_PATH_REQUEST_HANDLER_INFO);
     }
-
-    public String getName() {
-      return name;
-    }
-
-    public String getType() {
-      return type;
-    }
-
-    public String getClientConfig() {
-      return clientConfig;
-    }
-
-    public Config getRequestHandlerInfo() {
-      return requestHandlerInfo;
-    }
   }
 
+  @Value
+  @NonFinal
   public static class RequestHandlerClientConfig {
     private static final String CONFIG_PATH_TYPE = "type";
     private static final String CONFIG_PATH_CONNECTION_STRING = "connectionString";
-    private String type;
-    private String connectionString;
+    String type;
+    String connectionString;
 
     private RequestHandlerClientConfig(Config config) {
       this.type = config.getString(CONFIG_PATH_TYPE);
       this.connectionString = config.getString(CONFIG_PATH_CONNECTION_STRING);
     }
-
-    public String getType() {
-      return type;
-    }
-
-    public String getConnectionString() {
-      return connectionString;
-    }
   }
 
+  @Value
+  @NonFinal
   public static class ClientHostPortConfig {
     private static final String CONFIG_PATH_HOST = "host";
     private static final String CONFIG_PATH_PORT = "port";
-    private String host;
-    private int port;
+    String host;
+    int port;
 
     private ClientHostPortConfig(Config config) {
       this.host = config.getString(CONFIG_PATH_HOST);
       this.port = config.getInt(CONFIG_PATH_PORT);
     }
+  }
 
-    public String getHost() {
-      return this.host;
+  @Value
+  @NonFinal
+  public static class LimitValidationConfig {
+    private static final String CONFIG_PATH_MIN = "min";
+    private static final String CONFIG_PATH_MAX = "max";
+    private static final String CONFIG_PATH_MODE = "mode";
+    int min;
+    int max;
+    LimitValidationMode mode;
+
+    private LimitValidationConfig(Config config) {
+      this.min = config.getInt(CONFIG_PATH_MIN);
+      this.max = config.getInt(CONFIG_PATH_MAX);
+      this.mode = config.getEnum(LimitValidationMode.class, CONFIG_PATH_MODE);
     }
 
-    public int getPort() {
-      return this.port;
+    public enum LimitValidationMode {
+      DISABLED,
+      WARN,
+      ERROR
     }
   }
 }

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/QueryServiceModule.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/QueryServiceModule.java
@@ -10,6 +10,7 @@ import org.hypertrace.core.query.service.attribubteexpression.AttributeExpressio
 import org.hypertrace.core.query.service.pinot.PinotModule;
 import org.hypertrace.core.query.service.projection.ProjectionModule;
 import org.hypertrace.core.query.service.prometheus.PrometheusModule;
+import org.hypertrace.core.query.service.validation.QueryValidationModule;
 import org.hypertrace.core.serviceframework.spi.PlatformServiceLifecycle;
 
 class QueryServiceModule extends AbstractModule {
@@ -35,5 +36,6 @@ class QueryServiceModule extends AbstractModule {
     install(new ProjectionModule());
     install(new PrometheusModule());
     install(new AttributeExpressionModule());
+    install(new QueryValidationModule());
   }
 }

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/validation/LimitValidation.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/validation/LimitValidation.java
@@ -1,0 +1,60 @@
+package org.hypertrace.core.query.service.validation;
+
+import io.grpc.Status;
+import io.reactivex.rxjava3.core.Completable;
+import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import org.hypertrace.core.grpcutils.context.RequestContext;
+import org.hypertrace.core.query.service.QueryServiceConfig;
+import org.hypertrace.core.query.service.QueryServiceConfig.LimitValidationConfig;
+import org.hypertrace.core.query.service.api.QueryRequest;
+
+@Slf4j
+class LimitValidation implements QueryValidation {
+
+  LimitValidationConfig config;
+
+  @Inject
+  LimitValidation(QueryServiceConfig queryServiceConfig) {
+    this.config = queryServiceConfig.getLimitValidationConfig();
+  }
+
+  @Override
+  public Completable validate(QueryRequest queryRequest, RequestContext requestContext) {
+
+    switch (config.getMode()) {
+      case ERROR:
+        if (isInvalidLimit(queryRequest.getLimit())) {
+          return Completable.error(
+              Status.INVALID_ARGUMENT
+                  .withDescription(generateErrorMessageForLimit(queryRequest.getLimit()))
+                  .asException());
+        }
+        return Completable.complete();
+
+      case WARN:
+        if (isInvalidLimit(queryRequest.getLimit())) {
+          log.warn(
+              generateErrorMessageForLimit(queryRequest.getLimit())
+                  + ". Allowing due to warn mode.",
+              queryRequest.getLimit(),
+              config.getMin(),
+              config.getMax());
+        }
+        return Completable.complete();
+      case DISABLED:
+      default:
+        return Completable.complete();
+    }
+  }
+
+  private String generateErrorMessageForLimit(int limit) {
+    return String.format(
+        "Received invalid query limit of %s, required to be in range of [%s, %s]",
+        limit, config.getMin(), config.getMax());
+  }
+
+  private boolean isInvalidLimit(int limit) {
+    return limit < config.getMin() || limit > config.getMax();
+  }
+}

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/validation/QueryValidation.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/validation/QueryValidation.java
@@ -1,0 +1,9 @@
+package org.hypertrace.core.query.service.validation;
+
+import io.reactivex.rxjava3.core.Completable;
+import org.hypertrace.core.grpcutils.context.RequestContext;
+import org.hypertrace.core.query.service.api.QueryRequest;
+
+public interface QueryValidation {
+  Completable validate(QueryRequest queryRequest, RequestContext requestContext);
+}

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/validation/QueryValidationModule.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/validation/QueryValidationModule.java
@@ -1,0 +1,14 @@
+package org.hypertrace.core.query.service.validation;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.Multibinder;
+
+public class QueryValidationModule extends AbstractModule {
+  @Override
+  protected void configure() {
+    Multibinder<QueryValidation> validationMultibinder =
+        Multibinder.newSetBinder(binder(), QueryValidation.class);
+    validationMultibinder.addBinding().to(TenantValidation.class);
+    validationMultibinder.addBinding().to(LimitValidation.class);
+  }
+}

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/validation/QueryValidator.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/validation/QueryValidator.java
@@ -1,0 +1,28 @@
+package org.hypertrace.core.query.service.validation;
+
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Observable;
+import java.util.Set;
+import javax.inject.Inject;
+import org.hypertrace.core.grpcutils.context.RequestContext;
+import org.hypertrace.core.query.service.api.QueryRequest;
+
+/**
+ * Query validator invokes each registered validation, passing only if all complete succesfully.
+ * Validations may be performed in any order. Any failing validation is responsible for producing
+ * its own error which will be passed to the caller.
+ */
+public class QueryValidator {
+  private final Set<QueryValidation> validations;
+
+  @Inject
+  QueryValidator(Set<QueryValidation> validations) {
+    this.validations = validations;
+  }
+
+  public Completable validate(QueryRequest originalRequest, RequestContext requestContext) {
+    return Observable.fromIterable(validations)
+        .flatMapCompletable(
+            queryValidation -> queryValidation.validate(originalRequest, requestContext), true);
+  }
+}

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/validation/TenantValidation.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/validation/TenantValidation.java
@@ -1,0 +1,18 @@
+package org.hypertrace.core.query.service.validation;
+
+import io.grpc.Status;
+import io.reactivex.rxjava3.core.Completable;
+import java.util.function.Predicate;
+import org.hypertrace.core.grpcutils.context.RequestContext;
+import org.hypertrace.core.query.service.api.QueryRequest;
+
+class TenantValidation implements QueryValidation {
+  @Override
+  public Completable validate(QueryRequest queryRequest, RequestContext requestContext) {
+    if (requestContext.getTenantId().filter(Predicate.not(String::isEmpty)).isEmpty()) {
+      return Completable.error(
+          Status.INVALID_ARGUMENT.withDescription("Tenant ID is missing on request").asException());
+    }
+    return Completable.complete();
+  }
+}

--- a/query-service-impl/src/test/java/org/hypertrace/core/query/service/validation/LimitValidationTest.java
+++ b/query-service-impl/src/test/java/org/hypertrace/core/query/service/validation/LimitValidationTest.java
@@ -1,0 +1,78 @@
+package org.hypertrace.core.query.service.validation;
+
+import static org.hypertrace.core.query.service.QueryServiceConfig.LimitValidationConfig.LimitValidationMode.DISABLED;
+import static org.hypertrace.core.query.service.QueryServiceConfig.LimitValidationConfig.LimitValidationMode.ERROR;
+import static org.hypertrace.core.query.service.QueryServiceConfig.LimitValidationConfig.LimitValidationMode.WARN;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.grpc.StatusException;
+import io.reactivex.rxjava3.observers.TestObserver;
+import org.hypertrace.core.grpcutils.context.RequestContext;
+import org.hypertrace.core.query.service.QueryServiceConfig;
+import org.hypertrace.core.query.service.QueryServiceConfig.LimitValidationConfig.LimitValidationMode;
+import org.hypertrace.core.query.service.api.QueryRequest;
+import org.junit.jupiter.api.Test;
+
+class LimitValidationTest {
+  RequestContext mockRequestContext = new RequestContext();
+
+  @Test
+  void doesNotValidateIfDisabled() {
+    LimitValidation validation = new LimitValidation(buildConfig(1, 10, DISABLED));
+    TestObserver<Void> observer = new TestObserver<>();
+    validation
+        .validate(QueryRequest.newBuilder().setLimit(-124).build(), mockRequestContext)
+        .blockingSubscribe(observer);
+    observer.assertComplete();
+  }
+
+  @Test
+  void doesNotErrorOnInvalidLimitIfWarnMode() {
+    LimitValidation validation = new LimitValidation(buildConfig(1, 10, WARN));
+    TestObserver<Void> observer = new TestObserver<>();
+    validation
+        .validate(QueryRequest.newBuilder().setLimit(-124).build(), mockRequestContext)
+        .blockingSubscribe(observer);
+    observer.assertComplete();
+  }
+
+  @Test
+  void allowsValidLimit() {
+    LimitValidation validation = new LimitValidation(buildConfig(1, 10, ERROR));
+    TestObserver<Void> observer = new TestObserver<>();
+    validation
+        .validate(QueryRequest.newBuilder().setLimit(5).build(), mockRequestContext)
+        .blockingSubscribe(observer);
+    observer.assertComplete();
+  }
+
+  @Test
+  void errorsOnLimitMin() {
+    LimitValidation validation = new LimitValidation(buildConfig(1, 10, ERROR));
+    TestObserver<Void> observer = new TestObserver<>();
+    validation
+        .validate(QueryRequest.newBuilder().build(), mockRequestContext) // default 0
+        .blockingSubscribe(observer);
+    observer.assertError(StatusException.class);
+  }
+
+  @Test
+  void errorsOnLimitMax() {
+    LimitValidation validation = new LimitValidation(buildConfig(1, 10, ERROR));
+    TestObserver<Void> observer = new TestObserver<>();
+    validation
+        .validate(QueryRequest.newBuilder().setLimit(15).build(), mockRequestContext)
+        .blockingSubscribe(observer);
+    observer.assertError(StatusException.class);
+  }
+
+  QueryServiceConfig buildConfig(int min, int max, LimitValidationMode mode) {
+    QueryServiceConfig mockConfig = mock(QueryServiceConfig.class, RETURNS_DEEP_STUBS);
+    when(mockConfig.getLimitValidationConfig().getMin()).thenReturn(min);
+    when(mockConfig.getLimitValidationConfig().getMax()).thenReturn(max);
+    when(mockConfig.getLimitValidationConfig().getMode()).thenReturn(mode);
+    return mockConfig;
+  }
+}

--- a/query-service-impl/src/test/java/org/hypertrace/core/query/service/validation/QueryValidatorTest.java
+++ b/query-service-impl/src/test/java/org/hypertrace/core/query/service/validation/QueryValidatorTest.java
@@ -1,0 +1,75 @@
+package org.hypertrace.core.query.service.validation;
+
+import io.grpc.Status;
+import io.grpc.StatusException;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.exceptions.CompositeException;
+import io.reactivex.rxjava3.observers.TestObserver;
+import java.util.Set;
+import org.hypertrace.core.grpcutils.context.RequestContext;
+import org.hypertrace.core.query.service.api.QueryRequest;
+import org.junit.jupiter.api.Test;
+
+class QueryValidatorTest {
+  QueryRequest mockRequest = QueryRequest.getDefaultInstance();
+  RequestContext mockContext = new RequestContext();
+
+  @Test
+  void propagatesSingleError() {
+    TestObserver<Void> observer = new TestObserver<>();
+    QueryValidator validator =
+        new QueryValidator(
+            Set.of(new SuccessValidation(), new ErrorValidation(Status.UNKNOWN.asException())));
+    validator.validate(mockRequest, mockContext).blockingSubscribe(observer);
+    observer.assertError(StatusException.class);
+  }
+
+  @Test
+  void propagatesMultipleErrors() {
+    TestObserver<Void> observer = new TestObserver<>();
+    QueryValidator validator =
+        new QueryValidator(
+            Set.of(
+                new ErrorValidation(Status.DATA_LOSS.asException()),
+                new ErrorValidation(Status.UNKNOWN.asException())));
+    validator.validate(mockRequest, mockContext).blockingSubscribe(observer);
+    observer.assertError(CompositeException.class);
+  }
+
+  @Test
+  void propagatesSingleSuccess() {
+    TestObserver<Void> observer = new TestObserver<>();
+    QueryValidator validator = new QueryValidator(Set.of(new SuccessValidation()));
+    validator.validate(mockRequest, mockContext).blockingSubscribe(observer);
+    observer.assertComplete();
+  }
+
+  @Test
+  void propagatesMultipleSuccess() {
+    TestObserver<Void> observer = new TestObserver<>();
+    QueryValidator validator =
+        new QueryValidator(Set.of(new SuccessValidation(), new SuccessValidation()));
+    validator.validate(mockRequest, mockContext).blockingSubscribe(observer);
+    observer.assertComplete();
+  }
+
+  private static class ErrorValidation implements QueryValidation {
+    Exception exception;
+
+    ErrorValidation(Exception exception) {
+      this.exception = exception;
+    }
+
+    @Override
+    public Completable validate(QueryRequest queryRequest, RequestContext requestContext) {
+      return Completable.error(exception);
+    }
+  }
+
+  private static class SuccessValidation implements QueryValidation {
+    @Override
+    public Completable validate(QueryRequest queryRequest, RequestContext requestContext) {
+      return Completable.complete();
+    }
+  }
+}

--- a/query-service-impl/src/test/java/org/hypertrace/core/query/service/validation/TenantValidationTest.java
+++ b/query-service-impl/src/test/java/org/hypertrace/core/query/service/validation/TenantValidationTest.java
@@ -1,0 +1,37 @@
+package org.hypertrace.core.query.service.validation;
+
+import io.grpc.StatusException;
+import io.reactivex.rxjava3.observers.TestObserver;
+import org.hypertrace.core.grpcutils.context.RequestContext;
+import org.hypertrace.core.query.service.api.QueryRequest;
+import org.junit.jupiter.api.Test;
+
+class TenantValidationTest {
+  QueryRequest mockRequest = QueryRequest.getDefaultInstance();
+  TenantValidation tenantValidation = new TenantValidation();
+
+  @Test
+  void errorsOnMissingTenant() {
+    TestObserver<Void> observer = new TestObserver<>();
+    tenantValidation.validate(mockRequest, new RequestContext()).blockingSubscribe(observer);
+    observer.assertError(StatusException.class);
+  }
+
+  @Test
+  void errorsOnEmptyTenant() {
+    TestObserver<Void> observer = new TestObserver<>();
+    tenantValidation
+        .validate(mockRequest, RequestContext.forTenantId(""))
+        .blockingSubscribe(observer);
+    observer.assertError(StatusException.class);
+  }
+
+  @Test
+  void passesOnValidTenant() {
+    TestObserver<Void> observer = new TestObserver<>();
+    tenantValidation
+        .validate(mockRequest, RequestContext.forTenantId("good-id"))
+        .blockingSubscribe(observer);
+    observer.assertComplete();
+  }
+}

--- a/query-service-impl/src/test/resources/application.conf
+++ b/query-service-impl/src/test/resources/application.conf
@@ -8,6 +8,13 @@ service.config = {
     port = 9012
     port = ${?ATTRIBUTE_SERVICE_PORT_CONFIG}
   }
+  validation = {
+    limit = {
+      min = 1
+      max = 10000
+      mode = WARN
+    }
+  }
   clients = [
     {
       type = broker

--- a/query-service/src/main/resources/configs/common/application.conf
+++ b/query-service/src/main/resources/configs/common/application.conf
@@ -9,6 +9,13 @@ service.config = {
     port = 9012
     port = ${?ATTRIBUTE_SERVICE_PORT_CONFIG}
   }
+  validation = {
+    limit = {
+      min = 1
+      max = 10000
+      mode = WARN
+    }
+  }
   clients = [
     {
       type = zookeeper


### PR DESCRIPTION
## Description
This PR adds configurable limit validation. It supports setting a minimum limit (preventing things like negative values, or unlimited queries), maximum limit, and a mode. The three modes are WARN (which logs limit breaches, but does not reject them), ERROR (which... errors) and DISABLED (probably self explanatory). Min and Max values are inclusive. Defaults are set to a limit of 1-10K, in warn mode. In practice this means warning logs will fire for any unlimited query, or a query with a limit > 10K.

### Testing
Added new unit tests for all new code, as well as updating existing test paths.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
