### PR TITLE
chore: update dependency constraints and exclusions

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,22 +5,42 @@ ignore:
   SNYK-JAVA-LOG4J-572732:
     - '*':
         reason: no available replacement
-        expires: 2021-12-31T00:00:00.000Z
+        expires: 2022-05-31T00:00:00.000Z
   SNYK-JAVA-IONETTY-473694:
     - '*':
         reason: no available replacement
-        expires: 2021-12-31T00:00:00.000Z
+        expires: 2022-05-31T00:00:00.000Z
   SNYK-JAVA-IONETTY-1042268:
     - '*':
         reason: No replacement available
-        expires: 2021-12-31T00:00:00.000Z
+        expires: 2022-05-31T00:00:00.000Z
   SNYK-JAVA-LOG4J-1300176:
     - '*':
         reason: None Given
-        expires: 2021-12-31T00:00:00.000Z
+        expires: 2022-05-31T00:00:00.000Z
   SNYK-JAVA-LOG4J-2316893:
     - '*':
         reason: None Given
-        expires: 2021-12-31T00:00:00.000Z
+        expires: 2022-05-31T00:00:00.000Z
         created: 2021-12-14T18:05:26.628Z
+  SNYK-JAVA-LOG4J-2342645:
+    - '*':
+        reason: None Given
+        expires: 2022-05-31T00:00:00.000Z
+        created: 2022-03-16T03:39:38.957Z
+  SNYK-JAVA-LOG4J-2342646:
+    - '*':
+        reason: None Given
+        expires: 2022-05-31T00:00:00.000Z
+        created: 2022-03-16T03:39:56.875Z
+  SNYK-JAVA-LOG4J-2342647:
+    - '*':
+        reason: None Given
+        expires: 2022-05-31T00:00:00.000Z
+        created: 2022-03-16T03:40:04.704Z
+  SNYK-JAVA-ORGJETBRAINSKOTLIN-2393744:
+    - '*':
+        reason: None Given
+        expires: 2022-05-31T00:00:00.000Z
+        created: 2022-03-16T03:40:31.778Z
 patch: {}

--- a/query-service-api/build.gradle.kts
+++ b/query-service-api/build.gradle.kts
@@ -71,6 +71,12 @@ dependencies {
   api("io.grpc:grpc-stub")
   api("javax.annotation:javax.annotation-api:1.3.2")
 
+  constraints {
+    implementation("com.google.protobuf:protobuf-java:3.19.2") {
+      because("https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-2331703")
+    }
+  }
+
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("com.google.protobuf:protobuf-java-util:3.19.2")
 }


### PR DESCRIPTION
## Description
Updated vulnerable dependencies that had a new version available, put a short ignore on those that did not.
