### PR TITLE
fix: actually print offending request for limit warning

### DIFF
--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/validation/LimitValidation.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/validation/LimitValidation.java
@@ -36,10 +36,9 @@ class LimitValidation implements QueryValidation {
         if (isInvalidLimit(queryRequest.getLimit())) {
           log.warn(
               generateErrorMessageForLimit(queryRequest.getLimit())
-                  + ". Allowing due to warn mode.",
-              queryRequest.getLimit(),
-              config.getMin(),
-              config.getMax());
+                  + ". Allowing due to warn mode.{}{}",
+              System.lineSeparator(),
+              queryRequest);
         }
         return Completable.complete();
       case DISABLED:


### PR DESCRIPTION
## Description
Followup to https://github.com/hypertrace/query-service/pull/135 to actually print offending query in log message.