### PR TITLE
added error count of failed requests from query service to pinot

### DIFF
--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/QueryServiceImpl.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/QueryServiceImpl.java
@@ -30,6 +30,8 @@ class QueryServiceImpl extends QueryServiceGrpc.QueryServiceImplBase {
 
   private Counter serviceResponseErrorCounter;
   private Counter serviceResponseSuccessCounter;
+  private static final String ERROR_COUNTER_NAME = "hypertrace.query-service.response.errors";
+  private static final String SUCCESS_COUNTER_NAME = "hypertrace.query-service.response.success";
 
   class QueryServiceObserver<T> extends ServerCallStreamRxObserver<T> {
 
@@ -48,7 +50,6 @@ class QueryServiceImpl extends QueryServiceGrpc.QueryServiceImplBase {
       serviceResponseSuccessCounter.increment();
       super.onComplete();
     }
-
   }
 
   @Inject
@@ -62,17 +63,12 @@ class QueryServiceImpl extends QueryServiceGrpc.QueryServiceImplBase {
     initMetrics();
   }
 
-  private static final String ERROR_COUNTER_NAME = "hypertrace.query-service.response.errors";
-  private static final String SUCCESS_COUNTER_NAME = "hypertrace.query-service.response.success";
-
   private void initMetrics() {
     serviceResponseErrorCounter =
-            PlatformMetricsRegistry.registerCounter(
-                    ERROR_COUNTER_NAME, ImmutableMap.of());
+        PlatformMetricsRegistry.registerCounter(ERROR_COUNTER_NAME, ImmutableMap.of());
 
     serviceResponseSuccessCounter =
-            PlatformMetricsRegistry.registerCounter(
-                    SUCCESS_COUNTER_NAME, ImmutableMap.of());
+        PlatformMetricsRegistry.registerCounter(SUCCESS_COUNTER_NAME, ImmutableMap.of());
   }
 
   @Override

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/QueryServiceImpl.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/QueryServiceImpl.java
@@ -29,6 +29,7 @@ class QueryServiceImpl extends QueryServiceGrpc.QueryServiceImplBase {
   private final QueryValidator queryValidator;
 
   private Counter serviceResponseErrorCounter;
+  private Counter serviceResponseSuccessCounter;
 
   class QueryServiceObserver<T> extends ServerCallStreamRxObserver<T> {
 
@@ -40,6 +41,12 @@ class QueryServiceImpl extends QueryServiceGrpc.QueryServiceImplBase {
     public void onError(Throwable th) {
       serviceResponseErrorCounter.increment();
       super.onError(th);
+    }
+
+    @Override
+    public void onComplete() {
+      serviceResponseSuccessCounter.increment();
+      super.onComplete();
     }
 
   }
@@ -55,12 +62,17 @@ class QueryServiceImpl extends QueryServiceGrpc.QueryServiceImplBase {
     initMetrics();
   }
 
-  private static final String COUNTER_NAME = "hypertrace.query-service.response.errors";
+  private static final String ERROR_COUNTER_NAME = "hypertrace.query-service.response.errors";
+  private static final String SUCCESS_COUNTER_NAME = "hypertrace.query-service.response.success";
 
   private void initMetrics() {
     serviceResponseErrorCounter =
             PlatformMetricsRegistry.registerCounter(
-                    COUNTER_NAME, ImmutableMap.of());
+                    ERROR_COUNTER_NAME, ImmutableMap.of());
+
+    serviceResponseSuccessCounter =
+            PlatformMetricsRegistry.registerCounter(
+                    SUCCESS_COUNTER_NAME, ImmutableMap.of());
   }
 
   @Override


### PR DESCRIPTION
## Description
Currently, there are no metrics to track the number of failed requests in the data query layer. Adding an error counter to track requests failing in query service. The metric is exposed on /metrics endpoint.  


For gateway-service - [https://github.com/hypertrace/gateway-service/pull/128](url)