### PR TITLE
feat: add CONTAINS_KEY_LIKE operator

### DIFF
--- a/query-service-api/src/main/proto/request.proto
+++ b/query-service-api/src/main/proto/request.proto
@@ -56,6 +56,7 @@ enum Operator {
   CONTAINS_KEY = 13;
   CONTAINS_KEYVALUE = 14;
   NOT_CONTAINS_KEY = 15;
+  CONTAINS_KEY_LIKE = 16;
 }
 
 

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
@@ -357,7 +357,7 @@ class QueryRequestToPinotSQLConverter {
         literals.set(0, value.getValue().getString());
       } else {
         throw new IllegalArgumentException(
-            "Unsupported arguments for CONTAINS_KEY / CONTAINS_KEYVALUE operator");
+            "Unsupported arguments for CONTAINS_KEY / CONTAINS_KEYVALUE / CONTAINS_KEY_LIKE operator");
       }
     }
 

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
@@ -149,8 +149,13 @@ class QueryRequestToPinotSQLConverter {
               handleValueConversionForLiteralExpression(filter.getLhs(), filter.getRhs());
           builder.append(operator);
           builder.append("(");
-          builder.append(
-              convertExpressionToString(filter.getLhs(), paramsBuilder, executionContext));
+          if (isMapColumnName(filter.getLhs())) {
+            // supports Like operator on map key column
+            builder.append(convertExpressionToMapKeyColumn(filter.getLhs()));
+          } else {
+            builder.append(
+                convertExpressionToString(filter.getLhs(), paramsBuilder, executionContext));
+          }
           builder.append(",");
           builder.append(convertExpressionToString(rhs, paramsBuilder, executionContext));
           builder.append(")");
@@ -440,5 +445,9 @@ class QueryRequestToPinotSQLConverter {
         break;
     }
     return ret;
+  }
+
+  private boolean isMapColumnName(Expression expression) {
+    return getLogicalColumnName(expression).map(viewDefinition::isMap).orElse(false);
   }
 }

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
@@ -149,13 +149,8 @@ class QueryRequestToPinotSQLConverter {
               handleValueConversionForLiteralExpression(filter.getLhs(), filter.getRhs());
           builder.append(operator);
           builder.append("(");
-          if (isMapColumnName(filter.getLhs())) {
-            // supports Like operator on map key column
-            builder.append(convertExpressionToMapKeyColumn(filter.getLhs()));
-          } else {
-            builder.append(
-                convertExpressionToString(filter.getLhs(), paramsBuilder, executionContext));
-          }
+          builder.append(
+              convertExpressionToString(filter.getLhs(), paramsBuilder, executionContext));
           builder.append(",");
           builder.append(convertExpressionToString(rhs, paramsBuilder, executionContext));
           builder.append(")");
@@ -445,9 +440,5 @@ class QueryRequestToPinotSQLConverter {
         break;
     }
     return ret;
-  }
-
-  private boolean isMapColumnName(Expression expression) {
-    return getLogicalColumnName(expression).map(viewDefinition::isMap).orElse(false);
   }
 }

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
@@ -186,6 +186,15 @@ class QueryRequestToPinotSQLConverter {
           builder.append(") = ");
           builder.append(convertLiteralToString(kvp.get(MAP_VALUE_INDEX), paramsBuilder));
           break;
+        case CONTAINS_KEY_LIKE:
+          kvp = convertExpressionToMapLiterals(filter.getRhs());
+          builder.append(operator);
+          builder.append("(");
+          builder.append(convertExpressionToMapKeyColumn(filter.getLhs()));
+          builder.append(",");
+          builder.append(convertLiteralToString(kvp.get(MAP_KEY_INDEX), paramsBuilder));
+          builder.append(")");
+          break;
         default:
           rhs = handleValueConversionForLiteralExpression(filter.getLhs(), filter.getRhs());
           builder.append(
@@ -255,6 +264,7 @@ class QueryRequestToPinotSQLConverter {
       case LE:
         return "<=";
       case LIKE:
+      case CONTAINS_KEY_LIKE:
         return REGEX_OPERATOR;
       case CONTAINS_KEYVALUE:
         return MAP_VALUE;


### PR DESCRIPTION
## Description
This PR adds `CONTAINS_KEY_LIKE` operator for doing a regex based search on map fields (on map key column). 

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Added unit test.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules