### PR TITLE
fix: flip around division

### DIFF
--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/converters/PinotFunctionConverter.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/converters/PinotFunctionConverter.java
@@ -91,7 +91,7 @@ public class PinotFunctionConverter {
             .getSeconds();
 
     return String.format(
-        "SUM(%s / %s)", columnName, (double) aggregateIntervalInSeconds / rateIntervalInSeconds);
+        "SUM(%s) / %s", columnName, (double) aggregateIntervalInSeconds / rateIntervalInSeconds);
   }
 
   private String convertCount() {

--- a/query-service-impl/src/test/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverterTest.java
+++ b/query-service-impl/src/test/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverterTest.java
@@ -914,7 +914,7 @@ public class QueryRequestToPinotSQLConverterTest {
             + "' "
             + "and ( start_time_millis >= 1637297304041 and start_time_millis < 1637300904041 and service_id != 'null' ) "
             + "group by service_id, service_name "
-            + "order by SUM(error_count / 3600.0) "
+            + "order by SUM(error_count) / 3600.0 "
             + "limit 10000",
         viewDefinition,
         executionContext);

--- a/query-service-impl/src/test/java/org/hypertrace/core/query/service/pinot/converters/PinotFunctionConverterTest.java
+++ b/query-service-impl/src/test/java/org/hypertrace/core/query/service/pinot/converters/PinotFunctionConverterTest.java
@@ -211,7 +211,7 @@ class PinotFunctionConverterTest {
         .thenReturn(Optional.of(Duration.ofSeconds(10)));
 
     assertEquals(
-        "SUM(foo / 2.0)",
+        "SUM(foo) / 2.0",
         new PinotFunctionConverter()
             .convert(
                 mockingExecutionContext,
@@ -223,7 +223,7 @@ class PinotFunctionConverterTest {
         .thenReturn(Optional.of(Duration.ofSeconds(20)));
 
     assertEquals(
-        "SUM(foo / 4.0)",
+        "SUM(foo) / 4.0",
         new PinotFunctionConverter()
             .convert(
                 mockingExecutionContext,


### PR DESCRIPTION
## Description
Flip division from inside sum aggregation to outside, allowing pinot to optimize with star tree.

### Testing
Unit tests, verified optimization with pinot explain plain 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

