### PR TITLE
fix: add support for boolean array fields for pinot

### DIFF
--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
@@ -407,7 +407,7 @@ class QueryRequestToPinotSQLConverter {
         for (Boolean item : value.getBooleanArrayList()) {
           builder.append(delim);
           builder.append(QUESTION_MARK);
-          paramsBuilder.addStringParam(String.valueOf(item.booleanValue()));
+          paramsBuilder.addStringParam(String.valueOf(item));
           delim = ", ";
         }
         builder.append(")");

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
@@ -401,6 +401,18 @@ class QueryRequestToPinotSQLConverter {
         builder.append(")");
         ret = builder.toString();
         break;
+      case BOOLEAN_ARRAY:
+        builder = new StringBuilder("(");
+        delim = "";
+        for (Boolean item : value.getBooleanArrayList()) {
+          builder.append(delim);
+          builder.append(QUESTION_MARK);
+          paramsBuilder.addStringParam(String.valueOf(item.booleanValue()));
+          delim = ", ";
+        }
+        builder.append(")");
+        ret = builder.toString();
+        break;
       case STRING:
         ret = QUESTION_MARK;
         paramsBuilder.addStringParam(value.getString());
@@ -445,7 +457,6 @@ class QueryRequestToPinotSQLConverter {
       case INT_ARRAY:
       case FLOAT_ARRAY:
       case DOUBLE_ARRAY:
-      case BOOLEAN_ARRAY:
       case UNRECOGNIZED:
         break;
     }

--- a/query-service-impl/src/test/java/org/hypertrace/core/query/service/QueryRequestBuilderUtils.java
+++ b/query-service-impl/src/test/java/org/hypertrace/core/query/service/QueryRequestBuilderUtils.java
@@ -116,6 +116,10 @@ public class QueryRequestBuilderUtils {
     return Filter.newBuilder().setOperator(operator).addAllChildFilter(Arrays.asList(childFilters));
   }
 
+  public static Filter createBooleanArrayInFilter(String column, List<Boolean> values) {
+    return createFilter(column, Operator.IN, createBoolArrayLiteralValueExpression(values));
+  }
+
   public static Filter createInFilter(String column, List<String> values) {
     return createFilter(column, Operator.IN, createStringArrayLiteralValueExpression(values));
   }
@@ -242,6 +246,17 @@ public class QueryRequestBuilderUtils {
         .setLiteral(
             LiteralConstant.newBuilder()
                 .setValue(Value.newBuilder().setBoolean(value).setValueType(ValueType.BOOL)))
+        .build();
+  }
+
+  public static Expression createBoolArrayLiteralValueExpression(List<Boolean> values) {
+    return Expression.newBuilder()
+        .setLiteral(
+            LiteralConstant.newBuilder()
+                .setValue(
+                    Value.newBuilder()
+                        .addAllBooleanArray(values)
+                        .setValueType(ValueType.BOOLEAN_ARRAY)))
         .build();
   }
 

--- a/query-service-impl/src/test/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverterTest.java
+++ b/query-service-impl/src/test/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverterTest.java
@@ -2,6 +2,7 @@ package org.hypertrace.core.query.service.pinot;
 
 import static java.util.Objects.requireNonNull;
 import static org.hypertrace.core.query.service.QueryRequestBuilderUtils.createAliasedFunctionExpression;
+import static org.hypertrace.core.query.service.QueryRequestBuilderUtils.createBooleanArrayInFilter;
 import static org.hypertrace.core.query.service.QueryRequestBuilderUtils.createColumnExpression;
 import static org.hypertrace.core.query.service.QueryRequestBuilderUtils.createCountByColumnSelection;
 import static org.hypertrace.core.query.service.QueryRequestBuilderUtils.createEqualsFilter;
@@ -219,6 +220,25 @@ public class QueryRequestToPinotSQLConverterTest {
             + TENANT_ID
             + "' "
             + "AND is_entry = 'true'",
+        viewDefinition,
+        executionContext);
+  }
+
+  @Test
+  public void testQueryWithBooleanArrayFilter() {
+    QueryRequest queryRequest =
+        buildSimpleQueryWithFilter(createBooleanArrayInFilter("Span.is_entry", List.of(true)));
+    ViewDefinition viewDefinition = getDefaultViewDefinition();
+    defaultMockingForExecutionContext();
+
+    assertPQLQuery(
+        queryRequest,
+        "Select span_id FROM SpanEventView WHERE "
+            + viewDefinition.getTenantIdColumn()
+            + " = '"
+            + TENANT_ID
+            + "' "
+            + "AND is_entry in ('true')",
         viewDefinition,
         executionContext);
   }


### PR DESCRIPTION
## Description
This PR adds support for queries involving boolean array fields for Pinot.

Sample failing query  - 
```
{
    "filter": {
        "operator": "AND",
        "childFilter": [
            {
                "lhs": {
                    "attribute_expression": {
                        "attributeId": "API.isExternal",
                        "alias": "isExternal"
                    }
                },
                "rhs": {
                    "literal": {
                        "value": {
                            "valueType": "BOOLEAN_ARRAY",
                            "boolean_array": [false]
                        }
                    }
                },
                "operator":"IN"
            }
        ]
    },
    "limit": 1,
    "selection": [
        {
            "attribute_expression": {
                "attributeId": "API.isExternal",
                "alias": "isExternal"
            }
        }
    ]
}
```

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Added new unit tests for all new code, and ran all the existing unit tests.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

<!--
### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.


Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
