### PR TITLE
Added support for accurate distinct count on attributes through config

### DIFF
--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/converters/PinotFunctionConverterConfig.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/converters/PinotFunctionConverterConfig.java
@@ -1,10 +1,11 @@
 package org.hypertrace.core.query.service.pinot.converters;
 
-import com.google.common.collect.ImmutableSet;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import java.util.Collections;
-import java.util.Set;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -17,14 +18,13 @@ public class PinotFunctionConverterConfig {
   private static final String PERCENTILE_AGGREGATION_FUNCTION_CONFIG = "percentileAggFunction";
   private static final String DISTINCT_COUNT_AGGREGATION_FUNCTION_CONFIG =
       "distinctCountAggFunction";
-  private static final String ARGS_FOR_ACCURATE_DISTINCT_COUNT_AGG_CONFIG =
-      "argsForAccurateDistinctCountAgg";
+  private static final String DISTINCT_COUNT_AGGREGATION_OVERRIDES = "distinctCountAggOverrides";
   private static final String DEFAULT_PERCENTILE_AGGREGATION_FUNCTION = "PERCENTILETDIGEST";
-  private static final String ACCURATE_DISTINCT_COUNT_AGGREGATION_FUNCTION = "DISTINCTCOUNT";
+  private static final String DEFAULT_DISTINCT_COUNT_AGGREGATION_FUNCTION = "DISTINCTCOUNT";
 
   String percentileAggregationFunction;
   String distinctCountAggregationFunction;
-  @Nonnull Set<String> argsForAccurateDistinctCountAgg;
+  @Nonnull Map<String, String> distinctCountAggOverrides;
 
   public PinotFunctionConverterConfig(Config config) {
     if (config.hasPath(PERCENTILE_AGGREGATION_FUNCTION_CONFIG)) {
@@ -36,13 +36,17 @@ public class PinotFunctionConverterConfig {
       this.distinctCountAggregationFunction =
           config.getString(DISTINCT_COUNT_AGGREGATION_FUNCTION_CONFIG);
     } else {
-      this.distinctCountAggregationFunction = ACCURATE_DISTINCT_COUNT_AGGREGATION_FUNCTION;
+      this.distinctCountAggregationFunction = DEFAULT_DISTINCT_COUNT_AGGREGATION_FUNCTION;
     }
-    if (config.hasPath(ARGS_FOR_ACCURATE_DISTINCT_COUNT_AGG_CONFIG)) {
-      this.argsForAccurateDistinctCountAgg =
-          ImmutableSet.copyOf(config.getStringList(ARGS_FOR_ACCURATE_DISTINCT_COUNT_AGG_CONFIG));
+    if (config.hasPath(DISTINCT_COUNT_AGGREGATION_OVERRIDES)) {
+      Config overridesConfig = config.getConfig(DISTINCT_COUNT_AGGREGATION_OVERRIDES);
+      this.distinctCountAggOverrides =
+          overridesConfig.entrySet().stream()
+              .collect(
+                  Collectors.toMap(
+                      entry -> entry.getKey(), entry -> overridesConfig.getString(entry.getKey())));
     } else {
-      this.argsForAccurateDistinctCountAgg = Collections.emptySet();
+      this.distinctCountAggOverrides = Collections.emptyMap();
     }
   }
 
@@ -51,9 +55,7 @@ public class PinotFunctionConverterConfig {
   }
 
   public String getDistinctCountFunction(String arg) {
-    if (argsForAccurateDistinctCountAgg.contains(arg)) {
-      return ACCURATE_DISTINCT_COUNT_AGGREGATION_FUNCTION;
-    }
-    return distinctCountAggregationFunction;
+    return Optional.ofNullable(distinctCountAggOverrides.get(arg))
+        .orElse(distinctCountAggregationFunction);
   }
 }

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/converters/PinotFunctionConverterConfig.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/converters/PinotFunctionConverterConfig.java
@@ -1,22 +1,30 @@
 package org.hypertrace.core.query.service.pinot.converters;
 
+import com.google.common.collect.ImmutableSet;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import java.util.Collections;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Value;
 
 @Value
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 public class PinotFunctionConverterConfig {
 
   private static final String PERCENTILE_AGGREGATION_FUNCTION_CONFIG = "percentileAggFunction";
   private static final String DISTINCT_COUNT_AGGREGATION_FUNCTION_CONFIG =
       "distinctCountAggFunction";
+  private static final String ARGS_FOR_ACCURATE_DISTINCT_COUNT_AGG_CONFIG =
+      "argsForAccurateDistinctCountAgg";
   private static final String DEFAULT_PERCENTILE_AGGREGATION_FUNCTION = "PERCENTILETDIGEST";
-  private static final String DEFAULT_DISTINCT_COUNT_AGGREGATION_FUNCTION = "DISTINCTCOUNT";
+  private static final String ACCURATE_DISTINCT_COUNT_AGGREGATION_FUNCTION = "DISTINCTCOUNT";
 
   String percentileAggregationFunction;
   String distinctCountAggregationFunction;
+  @Nonnull Set<String> argsForAccurateDistinctCountAgg;
 
   public PinotFunctionConverterConfig(Config config) {
     if (config.hasPath(PERCENTILE_AGGREGATION_FUNCTION_CONFIG)) {
@@ -28,11 +36,24 @@ public class PinotFunctionConverterConfig {
       this.distinctCountAggregationFunction =
           config.getString(DISTINCT_COUNT_AGGREGATION_FUNCTION_CONFIG);
     } else {
-      this.distinctCountAggregationFunction = DEFAULT_DISTINCT_COUNT_AGGREGATION_FUNCTION;
+      this.distinctCountAggregationFunction = ACCURATE_DISTINCT_COUNT_AGGREGATION_FUNCTION;
+    }
+    if (config.hasPath(ARGS_FOR_ACCURATE_DISTINCT_COUNT_AGG_CONFIG)) {
+      this.argsForAccurateDistinctCountAgg =
+          ImmutableSet.copyOf(config.getStringList(ARGS_FOR_ACCURATE_DISTINCT_COUNT_AGG_CONFIG));
+    } else {
+      this.argsForAccurateDistinctCountAgg = Collections.emptySet();
     }
   }
 
   public PinotFunctionConverterConfig() {
     this(ConfigFactory.empty());
+  }
+
+  public String getDistinctCountFunction(String arg) {
+    if (argsForAccurateDistinctCountAgg.contains(arg)) {
+      return ACCURATE_DISTINCT_COUNT_AGGREGATION_FUNCTION;
+    }
+    return distinctCountAggregationFunction;
   }
 }

--- a/query-service-impl/src/test/java/org/hypertrace/core/query/service/pinot/converters/PinotFunctionConverterTest.java
+++ b/query-service-impl/src/test/java/org/hypertrace/core/query/service/pinot/converters/PinotFunctionConverterTest.java
@@ -20,7 +20,9 @@ import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.hypertrace.core.query.service.ExecutionContext;
 import org.hypertrace.core.query.service.api.Expression;
@@ -104,7 +106,8 @@ class PinotFunctionConverterTest {
 
     assertEquals(
         expected,
-        new PinotFunctionConverter(new PinotFunctionConverterConfig("CUSTOMPERCENTILE", null))
+        new PinotFunctionConverter(
+                new PinotFunctionConverterConfig("CUSTOMPERCENTILE", null, Collections.emptySet()))
             .convert(mockingExecutionContext, percentileFunction, this.mockArgumentConverter));
   }
 
@@ -233,25 +236,42 @@ class PinotFunctionConverterTest {
 
   @Test
   void convertsDistinctCountFunction() {
-    Expression column = createColumnExpression("foo").build();
+    Expression column1 = createColumnExpression("foo").build();
+    Expression column2 = createColumnExpression("bar").build();
 
-    when(this.mockArgumentConverter.apply(column)).thenReturn("foo");
+    when(this.mockArgumentConverter.apply(column1)).thenReturn("foo");
+    when(this.mockArgumentConverter.apply(column2)).thenReturn("bar");
 
     assertEquals(
         "DISTINCTCOUNT(foo)",
         new PinotFunctionConverter()
             .convert(
                 mockingExecutionContext,
-                buildFunction(QUERY_FUNCTION_DISTINCTCOUNT, column.toBuilder()),
+                buildFunction(QUERY_FUNCTION_DISTINCTCOUNT, column1.toBuilder()),
                 this.mockArgumentConverter));
-
     assertEquals(
-        "CUSTOM_DC(foo)",
-        new PinotFunctionConverter(new PinotFunctionConverterConfig(null, "CUSTOM_DC"))
+        "DISTINCTCOUNT(bar)",
+        new PinotFunctionConverter()
             .convert(
                 mockingExecutionContext,
-                buildFunction(QUERY_FUNCTION_DISTINCTCOUNT, column.toBuilder()),
+                buildFunction(QUERY_FUNCTION_DISTINCTCOUNT, column2.toBuilder()),
                 this.mockArgumentConverter));
+
+    PinotFunctionConverter converter =
+        new PinotFunctionConverter(
+            new PinotFunctionConverterConfig(null, "CUSTOM_DC", Set.of("bar")));
+    assertEquals(
+        "CUSTOM_DC(foo)",
+        converter.convert(
+            mockingExecutionContext,
+            buildFunction(QUERY_FUNCTION_DISTINCTCOUNT, column1.toBuilder()),
+            this.mockArgumentConverter));
+    assertEquals(
+        "DISTINCTCOUNT(bar)",
+        converter.convert(
+            mockingExecutionContext,
+            buildFunction(QUERY_FUNCTION_DISTINCTCOUNT, column2.toBuilder()),
+            this.mockArgumentConverter));
   }
 
   @Test

--- a/query-service-impl/src/test/java/org/hypertrace/core/query/service/pinot/converters/PinotFunctionConverterTest.java
+++ b/query-service-impl/src/test/java/org/hypertrace/core/query/service/pinot/converters/PinotFunctionConverterTest.java
@@ -18,11 +18,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import com.typesafe.config.ConfigFactory;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.hypertrace.core.query.service.ExecutionContext;
 import org.hypertrace.core.query.service.api.Expression;
@@ -107,7 +107,7 @@ class PinotFunctionConverterTest {
     assertEquals(
         expected,
         new PinotFunctionConverter(
-                new PinotFunctionConverterConfig("CUSTOMPERCENTILE", null, Collections.emptySet()))
+                new PinotFunctionConverterConfig("CUSTOMPERCENTILE", null, Collections.emptyMap()))
             .convert(mockingExecutionContext, percentileFunction, this.mockArgumentConverter));
   }
 
@@ -259,7 +259,8 @@ class PinotFunctionConverterTest {
 
     PinotFunctionConverter converter =
         new PinotFunctionConverter(
-            new PinotFunctionConverterConfig(null, "CUSTOM_DC", Set.of("bar")));
+            new PinotFunctionConverterConfig(
+                ConfigFactory.parseString("distinctCountAggOverrides = {foo=CUSTOM_DC, xyz=XYZ}")));
     assertEquals(
         "CUSTOM_DC(foo)",
         converter.convert(


### PR DESCRIPTION
Existing config supports configuring the distinct count aggregation function for a given scope for all attributes. But we might need accurate distinct count on some attributes if the default is set to the approximate function. Defined a way to configure such attributes.
