### PR TITLE
ENG-26854: Fix vulnerabilities in query-service

### DIFF
--- a/query-service-api/build.gradle.kts
+++ b/query-service-api/build.gradle.kts
@@ -72,5 +72,5 @@ dependencies {
   api("javax.annotation:javax.annotation-api:1.3.2")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
-  testImplementation("com.google.protobuf:protobuf-java-util:3.20.3")
+  testImplementation("com.google.protobuf:protobuf-java-util:3.22.0")
 }

--- a/query-service-api/build.gradle.kts
+++ b/query-service-api/build.gradle.kts
@@ -66,7 +66,7 @@ tasks.test {
 }
 
 dependencies {
-  api(platform("io.grpc:grpc-bom:1.45.2"))
+  api(platform("io.grpc:grpc-bom:1.50.0"))
   api("io.grpc:grpc-protobuf")
   api("io.grpc:grpc-stub")
   api("javax.annotation:javax.annotation-api:1.3.2")

--- a/query-service-api/build.gradle.kts
+++ b/query-service-api/build.gradle.kts
@@ -66,11 +66,11 @@ tasks.test {
 }
 
 dependencies {
-  api(platform("io.grpc:grpc-bom:1.45.1"))
+  api(platform("io.grpc:grpc-bom:1.45.2"))
   api("io.grpc:grpc-protobuf")
   api("io.grpc:grpc-stub")
   api("javax.annotation:javax.annotation-api:1.3.2")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
-  testImplementation("com.google.protobuf:protobuf-java-util:3.20.1")
+  testImplementation("com.google.protobuf:protobuf-java-util:3.20.3")
 }

--- a/query-service-factory/build.gradle.kts
+++ b/query-service-factory/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api("org.hypertrace.core.serviceframework:platform-grpc-service-framework:0.1.48")
+  api("org.hypertrace.core.serviceframework:platform-grpc-service-framework:0.1.49")
 
   implementation(project(":query-service-impl"))
   implementation("com.google.inject:guice:5.0.1")

--- a/query-service-factory/build.gradle.kts
+++ b/query-service-factory/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api("org.hypertrace.core.serviceframework:platform-grpc-service-framework:0.1.47")
+  api("org.hypertrace.core.serviceframework:platform-grpc-service-framework:0.1.48")
 
   implementation(project(":query-service-impl"))
   implementation("com.google.inject:guice:5.0.1")

--- a/query-service-impl/build.gradle.kts
+++ b/query-service-impl/build.gradle.kts
@@ -67,7 +67,7 @@ dependencies {
   }
   implementation("org.slf4j:slf4j-api:1.7.32")
   implementation("commons-codec:commons-codec:1.15")
-  implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.48")
+  implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.49")
   implementation("com.google.protobuf:protobuf-java-util:3.20.3")
   implementation("com.google.guava:guava:31.1-jre")
   implementation("io.reactivex.rxjava3:rxjava:3.0.11")

--- a/query-service-impl/build.gradle.kts
+++ b/query-service-impl/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
   implementation("org.apache.pinot:pinot-java-client:0.12.0") {
     // We want to use log4j2 impl so exclude the log4j binding of slf4j
     exclude("org.slf4j", "slf4j-log4j12")
+    exclude("log4j", "log4j")
   }
   constraints {
     implementation("com.fasterxml.jackson.core:jackson-databind:2.13.4.2") {

--- a/query-service-impl/build.gradle.kts
+++ b/query-service-impl/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
           "in org.jetbrains.kotlin:kotlin-stdlib@1.4.10"
       )
     }
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.4.2") {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.14.2") {
       because("Multiple vulnerabilities")
     }
   }

--- a/query-service-impl/build.gradle.kts
+++ b/query-service-impl/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     implementation("io.netty:netty-common:4.1.77.Final") {
       because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-2812456")
     }
-    implementation("org.apache.zookeeper:zookeeper:3.6.2") {
+    implementation("org.apache.zookeeper:zookeeper:3.6.3") {
       because("Multiple vulnerabilities")
     }
     implementation("io.netty:netty-transport-native-epoll:4.1.71.Final") {
@@ -41,18 +41,38 @@ dependencies {
   implementation("org.hypertrace.core.attribute.service:attribute-projection-registry:0.12.3")
   implementation("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.12.3")
   implementation("com.google.inject:guice:5.0.1")
-  implementation("org.apache.pinot:pinot-java-client:0.6.0") {
+  implementation("org.apache.pinot:pinot-java-client:0.12.0") {
     // We want to use log4j2 impl so exclude the log4j binding of slf4j
     exclude("org.slf4j", "slf4j-log4j12")
   }
+  constraints {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.4.2") {
+      because("version 2.12.7.1 has a vulnerability https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424")
+    }
+    implementation("org.apache.calcite:calcite-core:1.32.0") {
+      because("version 1.29.0 has a vulnerability https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECALCITE-3021143")
+    }
+    implementation("org.apache.calcite.avatica:avatica-core:1.22.0") {
+      because("version 1.20.0 has a vulnerability https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECALCITEAVATICA-2961770")
+    }
+    implementation("commons-httpclient:commons-httpclient:3.1-jenkins-3") {
+      because("version 3.1 has a vulnerability https://security.snyk.io/vuln/SNYK-JAVA-COMMONSHTTPCLIENT-30083")
+    }
+    implementation("io.netty:netty-codec-http:4.1.71.Final") {
+      because("version 4.1.60.Final has a vulnerability https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-2314893")
+    }
+    implementation("org.webjars:swagger-ui:4.1.3") {
+      because("version 3.23.11 has a vulnerability https://security.snyk.io/vuln/SNYK-JAVA-ORGWEBJARS-2314887")
+    }
+  }
   implementation("org.slf4j:slf4j-api:1.7.32")
   implementation("commons-codec:commons-codec:1.15")
-  implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.47")
-  implementation("com.google.protobuf:protobuf-java-util:3.20.1")
+  implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.48")
+  implementation("com.google.protobuf:protobuf-java-util:3.20.3")
   implementation("com.google.guava:guava:31.1-jre")
   implementation("io.reactivex.rxjava3:rxjava:3.0.11")
   implementation("com.squareup.okhttp3:okhttp:4.9.3")
-  implementation("org.postgresql:postgresql:42.4.1")
+  implementation("org.postgresql:postgresql:42.4.3")
 
   annotationProcessor("org.projectlombok:lombok:1.18.20")
   compileOnly("org.projectlombok:lombok:1.18.20")
@@ -63,4 +83,9 @@ dependencies {
   testImplementation("org.mockito:mockito-junit-jupiter:3.8.0")
   testImplementation("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1")
   testImplementation("com.squareup.okhttp3:mockwebserver:4.9.3")
+  constraints {
+    testImplementation("junit:junit:4.13.1") {
+      because("version 4.13 has a vulnerability https://security.snyk.io/vuln/SNYK-JAVA-JUNIT-1017047")
+    }
+  }
 }

--- a/query-service-impl/build.gradle.kts
+++ b/query-service-impl/build.gradle.kts
@@ -31,6 +31,9 @@ dependencies {
           "in org.jetbrains.kotlin:kotlin-stdlib@1.4.10"
       )
     }
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.4.2") {
+      because("Multiple vulnerabilities")
+    }
   }
   api(project(":query-service-api"))
   api("com.typesafe:config:1.4.1")
@@ -41,30 +44,10 @@ dependencies {
   implementation("org.hypertrace.core.attribute.service:attribute-projection-registry:0.12.3")
   implementation("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.12.3")
   implementation("com.google.inject:guice:5.0.1")
-  implementation("org.apache.pinot:pinot-java-client:0.12.0") {
+  implementation("org.apache.pinot:pinot-java-client:0.10.0") {
     // We want to use log4j2 impl so exclude the log4j binding of slf4j
     exclude("org.slf4j", "slf4j-log4j12")
     exclude("log4j", "log4j")
-  }
-  constraints {
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.4.2") {
-      because("version 2.12.7.1 has a vulnerability https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424")
-    }
-    implementation("org.apache.calcite:calcite-core:1.32.0") {
-      because("version 1.29.0 has a vulnerability https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECALCITE-3021143")
-    }
-    implementation("org.apache.calcite.avatica:avatica-core:1.22.0") {
-      because("version 1.20.0 has a vulnerability https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECALCITEAVATICA-2961770")
-    }
-    implementation("commons-httpclient:commons-httpclient:3.1-jenkins-3") {
-      because("version 3.1 has a vulnerability https://security.snyk.io/vuln/SNYK-JAVA-COMMONSHTTPCLIENT-30083")
-    }
-    implementation("io.netty:netty-codec-http:4.1.71.Final") {
-      because("version 4.1.60.Final has a vulnerability https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-2314893")
-    }
-    implementation("org.webjars:swagger-ui:4.1.3") {
-      because("version 3.23.11 has a vulnerability https://security.snyk.io/vuln/SNYK-JAVA-ORGWEBJARS-2314887")
-    }
   }
   implementation("org.slf4j:slf4j-api:1.7.32")
   implementation("commons-codec:commons-codec:1.15")

--- a/query-service-impl/build.gradle.kts
+++ b/query-service-impl/build.gradle.kts
@@ -68,7 +68,7 @@ dependencies {
   implementation("org.slf4j:slf4j-api:1.7.32")
   implementation("commons-codec:commons-codec:1.15")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.49")
-  implementation("com.google.protobuf:protobuf-java-util:3.20.3")
+  implementation("com.google.protobuf:protobuf-java-util:3.22.0")
   implementation("com.google.guava:guava:31.1-jre")
   implementation("io.reactivex.rxjava3:rxjava:3.0.11")
   implementation("com.squareup.okhttp3:okhttp:4.9.3")
@@ -83,9 +83,4 @@ dependencies {
   testImplementation("org.mockito:mockito-junit-jupiter:3.8.0")
   testImplementation("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1")
   testImplementation("com.squareup.okhttp3:mockwebserver:4.9.3")
-  constraints {
-    testImplementation("junit:junit:4.13.1") {
-      because("version 4.13 has a vulnerability https://security.snyk.io/vuln/SNYK-JAVA-JUNIT-1017047")
-    }
-  }
 }

--- a/query-service/build.gradle.kts
+++ b/query-service/build.gradle.kts
@@ -11,13 +11,13 @@ plugins {
 dependencies {
   implementation(project(":query-service-factory"))
   implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.11.2")
-  implementation("org.hypertrace.core.serviceframework:platform-grpc-service-framework:0.1.47")
+  implementation("org.hypertrace.core.serviceframework:platform-grpc-service-framework:0.1.48")
   implementation("org.slf4j:slf4j-api:1.7.32")
   implementation("com.typesafe:config:1.4.1")
 
   runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1")
   runtimeOnly("io.grpc:grpc-netty")
-  integrationTestImplementation("com.google.protobuf:protobuf-java-util:3.20.1")
+  integrationTestImplementation("com.google.protobuf:protobuf-java-util:3.20.3")
   integrationTestImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   integrationTestImplementation("org.testcontainers:testcontainers:1.16.2")
   integrationTestImplementation("org.testcontainers:junit-jupiter:1.16.2")
@@ -27,7 +27,12 @@ dependencies {
 
   integrationTestImplementation("org.apache.kafka:kafka-clients:5.5.1-ccs")
   integrationTestImplementation("org.apache.kafka:kafka-streams:5.5.1-ccs")
-  integrationTestImplementation("org.apache.avro:avro:1.11.0")
+  integrationTestImplementation("org.apache.avro:avro:1.11.1")
+  constraints {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.4.2") {
+      because("version 2.12.7.1 has a vulnerability https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424")
+    }
+  }
   integrationTestImplementation("com.google.guava:guava:31.1-jre")
   integrationTestImplementation("org.hypertrace.core.datamodel:data-model:0.1.12")
   integrationTestImplementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-serdes:0.1.13")

--- a/query-service/build.gradle.kts
+++ b/query-service/build.gradle.kts
@@ -28,11 +28,6 @@ dependencies {
   integrationTestImplementation("org.apache.kafka:kafka-clients:5.5.1-ccs")
   integrationTestImplementation("org.apache.kafka:kafka-streams:5.5.1-ccs")
   integrationTestImplementation("org.apache.avro:avro:1.11.1")
-  constraints {
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.4.2") {
-      because("version 2.12.7.1 has a vulnerability https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424")
-    }
-  }
   integrationTestImplementation("com.google.guava:guava:31.1-jre")
   integrationTestImplementation("org.hypertrace.core.datamodel:data-model:0.1.12")
   integrationTestImplementation("org.hypertrace.core.kafkastreams.framework:kafka-streams-serdes:0.1.13")

--- a/query-service/build.gradle.kts
+++ b/query-service/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 dependencies {
   implementation(project(":query-service-factory"))
   implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.11.2")
-  implementation("org.hypertrace.core.serviceframework:platform-grpc-service-framework:0.1.48")
+  implementation("org.hypertrace.core.serviceframework:platform-grpc-service-framework:0.1.49")
   implementation("org.slf4j:slf4j-api:1.7.32")
   implementation("com.typesafe:config:1.4.1")
 
@@ -22,7 +22,7 @@ dependencies {
   integrationTestImplementation("org.testcontainers:testcontainers:1.16.2")
   integrationTestImplementation("org.testcontainers:junit-jupiter:1.16.2")
   integrationTestImplementation("org.testcontainers:kafka:1.16.2")
-  integrationTestImplementation("org.hypertrace.core.serviceframework:integrationtest-service-framework:0.1.47")
+  integrationTestImplementation("org.hypertrace.core.serviceframework:integrationtest-service-framework:0.1.49")
   integrationTestImplementation("com.github.stefanbirkner:system-lambda:1.2.0")
 
   integrationTestImplementation("org.apache.kafka:kafka-clients:5.5.1-ccs")

--- a/query-service/build.gradle.kts
+++ b/query-service/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
 
   runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1")
   runtimeOnly("io.grpc:grpc-netty")
-  integrationTestImplementation("com.google.protobuf:protobuf-java-util:3.20.3")
+  integrationTestImplementation("com.google.protobuf:protobuf-java-util:3.22.0")
   integrationTestImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   integrationTestImplementation("org.testcontainers:testcontainers:1.16.2")
   integrationTestImplementation("org.testcontainers:junit-jupiter:1.16.2")


### PR DESCRIPTION
Fix vulnerabilities -

```
Testing /Users/kshitizsaxena/SourceCode/hypertrace/query-service...

Organization:      saxenakshitiz
Package manager:   gradle
Target file:       build.gradle.kts
Project name:      query-service
Open source:       no
Project path:      /Users/kshitizsaxena/SourceCode/hypertrace/query-service
Local Snyk policy: found
Licenses:          enabled

✔ Tested /Users/kshitizsaxena/SourceCode/hypertrace/query-service for known issues, no vulnerable paths found.

Next steps:
- Run `snyk monitor` to be notified about new related vulnerabilities.
- Run `snyk test` as part of your CI/test.

-------------------------------------------------------

Testing /Users/kshitizsaxena/SourceCode/hypertrace/query-service...

Tested 102 dependencies for known issues, found 5 issues, 14 vulnerable paths.


Issues to fix by upgrading:

  Upgrade org.apache.avro:avro@1.11.0 to org.apache.avro:avro@1.11.1 to fix
  ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] in com.fasterxml.jackson.core:jackson-databind@2.12.5
    introduced by org.apache.avro:avro@1.11.0 > com.fasterxml.jackson.core:jackson-databind@2.12.5 and 2 other path(s)
  ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in com.fasterxml.jackson.core:jackson-databind@2.12.5
    introduced by org.apache.avro:avro@1.11.0 > com.fasterxml.jackson.core:jackson-databind@2.12.5 and 2 other path(s)


Issues with no direct upgrade or patch:
  ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424] in com.fasterxml.jackson.core:jackson-databind@2.12.5
    introduced by org.apache.avro:avro@1.11.0 > com.fasterxml.jackson.core:jackson-databind@2.12.5 and 2 other path(s)
  This issue was fixed in versions: 2.13.4
  ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038426] in com.fasterxml.jackson.core:jackson-databind@2.12.5
    introduced by org.apache.avro:avro@1.11.0 > com.fasterxml.jackson.core:jackson-databind@2.12.5 and 2 other path(s)
  This issue was fixed in versions: 2.12.7.1, 2.13.4.2
  ✗ Improper Certificate Validation [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-1042268] in io.netty:netty-handler@4.1.86.Final
    introduced by io.grpc:grpc-netty@1.50.0 > io.netty:netty-codec-http2@4.1.86.Final > io.netty:netty-handler@4.1.86.Final and 1 other path(s)
  No upgrade or patch available



Organization:      saxenakshitiz
Package manager:   gradle
Target file:       build.gradle.kts
Project name:      query-service/query-service
Open source:       no
Project path:      /Users/kshitizsaxena/SourceCode/hypertrace/query-service
Licenses:          enabled

-------------------------------------------------------

Testing /Users/kshitizsaxena/SourceCode/hypertrace/query-service...

Tested 29 dependencies for known issues, found 3 issues, 9 vulnerable paths.


Issues to fix by upgrading:

  Upgrade com.google.protobuf:protobuf-java-util@3.20.1 to com.google.protobuf:protobuf-java-util@3.20.3 to fix
  ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-3040284] in com.google.protobuf:protobuf-java@3.19.2
    introduced by io.grpc:grpc-protobuf@1.45.1 > com.google.protobuf:protobuf-java@3.19.2 and 2 other path(s)
  ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-3167772] in com.google.protobuf:protobuf-java@3.19.2
    introduced by io.grpc:grpc-protobuf@1.45.1 > com.google.protobuf:protobuf-java@3.19.2 and 2 other path(s)
  ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-3167774] in com.google.protobuf:protobuf-java@3.19.2
    introduced by io.grpc:grpc-protobuf@1.45.1 > com.google.protobuf:protobuf-java@3.19.2 and 2 other path(s)

  Upgrade io.grpc:grpc-protobuf@1.45.1 to io.grpc:grpc-protobuf@1.45.2 to fix
  ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-3040284] in com.google.protobuf:protobuf-java@3.19.2
    introduced by io.grpc:grpc-protobuf@1.45.1 > com.google.protobuf:protobuf-java@3.19.2 and 2 other path(s)
  ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-3167772] in com.google.protobuf:protobuf-java@3.19.2
    introduced by io.grpc:grpc-protobuf@1.45.1 > com.google.protobuf:protobuf-java@3.19.2 and 2 other path(s)
  ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-3167774] in com.google.protobuf:protobuf-java@3.19.2
    introduced by io.grpc:grpc-protobuf@1.45.1 > com.google.protobuf:protobuf-java@3.19.2 and 2 other path(s)



Organization:      saxenakshitiz
Package manager:   gradle
Target file:       build.gradle.kts
Project name:      query-service/query-service-api
Open source:       no
Project path:      /Users/kshitizsaxena/SourceCode/hypertrace/query-service
Licenses:          enabled

-------------------------------------------------------

Testing /Users/kshitizsaxena/SourceCode/hypertrace/query-service...

Organization:      saxenakshitiz
Package manager:   gradle
Target file:       build.gradle.kts
Project name:      query-service/query-service-client
Open source:       no
Project path:      /Users/kshitizsaxena/SourceCode/hypertrace/query-service
Licenses:          enabled

✔ Tested 30 dependencies for known issues, no vulnerable paths found.

Next steps:
- Run `snyk monitor` to be notified about new related vulnerabilities.
- Run `snyk test` as part of your CI/test.

-------------------------------------------------------

Testing /Users/kshitizsaxena/SourceCode/hypertrace/query-service...

Organization:      saxenakshitiz
Package manager:   gradle
Target file:       build.gradle.kts
Project name:      query-service/query-service-factory
Open source:       no
Project path:      /Users/kshitizsaxena/SourceCode/hypertrace/query-service
Licenses:          enabled

✔ Tested 30 dependencies for known issues, no vulnerable paths found.

Next steps:
- Run `snyk monitor` to be notified about new related vulnerabilities.
- Run `snyk test` as part of your CI/test.

-------------------------------------------------------

Testing /Users/kshitizsaxena/SourceCode/hypertrace/query-service...

Tested 95 dependencies for known issues, found 61 issues, 70 vulnerable paths.


Issues to fix by upgrading:

  Upgrade org.apache.pinot:pinot-java-client@0.6.0 to org.apache.pinot:pinot-java-client@0.11.0 to fix
  ✗ XML External Entity (XXE) Injection [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-1048302] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-1009829] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-1047324] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-1052449] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-1052450] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-1054588] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-1056414] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-1056416] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-1056417] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-1056418] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-1056419] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-1056420] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-1056421] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-1056424] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-1056425] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-1056426] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-1056427] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-1061931] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-174736] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-450207] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-450917] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-455617] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-467014] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-467015] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-467016] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-469674] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-469676] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-471943] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-472980] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-540500] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-548451] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-559094] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-559106] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-560762] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-560766] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-561362] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-561373] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-561585] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-561586] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-561587] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-564887] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-564888] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-570625] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-572300] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-572314] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-572316] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-608664] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8

  Upgrade org.postgresql:postgresql@42.4.1 to org.postgresql:postgresql@42.4.3 to fix
  ✗ Information Exposure [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGPOSTGRESQL-3146847] in org.postgresql:postgresql@42.4.1
    introduced by org.postgresql:postgresql@42.4.1


Issues with no direct upgrade or patch:
  ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  This issue was fixed in versions: 2.13.4
  ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038426] in com.fasterxml.jackson.core:jackson-databind@2.9.8
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.fasterxml.jackson.core:jackson-databind@2.9.8
  This issue was fixed in versions: 2.12.7.1, 2.13.4.2
  ✗ Improper Certificate Validation [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-1042268] in io.netty:netty-handler@4.1.86.Final
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.101tec:zkclient@0.7 > org.apache.zookeeper:zookeeper@3.6.2 > io.netty:netty-handler@4.1.86.Final
  No upgrade or patch available
  ✗ HTTP Request Smuggling [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-473694] in io.netty:netty@3.10.6.Final
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > io.netty:netty@3.10.6.Final
  No upgrade or patch available
  ✗ Information Exposure [Low Severity][https://security.snyk.io/vuln/SNYK-JAVA-JUNIT-1017047] in junit:junit@4.13
    introduced by com.squareup.okhttp3:mockwebserver@4.9.3 > junit:junit@4.13
  This issue was fixed in versions: 4.13.1
  ✗ Man-in-the-Middle (MitM) [Low Severity][https://security.snyk.io/vuln/SNYK-JAVA-LOG4J-1300176] in log4j:log4j@1.2.17
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.101tec:zkclient@0.7 > log4j:log4j@1.2.17 and 1 other path(s)
  No upgrade or patch available
  ✗ Arbitrary Code Execution [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-LOG4J-2316893] in log4j:log4j@1.2.17
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.101tec:zkclient@0.7 > log4j:log4j@1.2.17 and 1 other path(s)
  No upgrade or patch available
  ✗ SQL Injection [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-LOG4J-2342645] in log4j:log4j@1.2.17
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.101tec:zkclient@0.7 > log4j:log4j@1.2.17 and 1 other path(s)
  No upgrade or patch available
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-LOG4J-2342646] in log4j:log4j@1.2.17
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.101tec:zkclient@0.7 > log4j:log4j@1.2.17 and 1 other path(s)
  No upgrade or patch available
  ✗ Deserialization of Untrusted Data [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-LOG4J-2342647] in log4j:log4j@1.2.17
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.101tec:zkclient@0.7 > log4j:log4j@1.2.17 and 1 other path(s)
  No upgrade or patch available
  ✗ Deserialization of Untrusted Data [Critical Severity][https://security.snyk.io/vuln/SNYK-JAVA-LOG4J-572732] in log4j:log4j@1.2.17
    introduced by org.apache.pinot:pinot-java-client@0.6.0 > com.101tec:zkclient@0.7 > log4j:log4j@1.2.17 and 1 other path(s)
  No upgrade or patch available
  ✗ Information Exposure [Low Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGJETBRAINSKOTLIN-2393744] in org.jetbrains.kotlin:kotlin-stdlib@1.6.0
    introduced by com.squareup.okhttp3:okhttp@4.9.3 > org.jetbrains.kotlin:kotlin-stdlib@1.6.0 and 3 other path(s)
  No upgrade or patch available



Organization:      saxenakshitiz
Package manager:   gradle
Target file:       build.gradle.kts
Project name:      query-service/query-service-impl
Open source:       no
Project path:      /Users/kshitizsaxena/SourceCode/hypertrace/query-service
Licenses:          enabled


Tested 6 projects, 3 contained vulnerable paths.
```