### PR TITLE
fix: fix runtime failure

### DIFF
--- a/query-service-impl/build.gradle.kts
+++ b/query-service-impl/build.gradle.kts
@@ -34,6 +34,9 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:2.14.2") {
       because("Multiple vulnerabilities")
     }
+    implementation("com.101tec:zkclient:0.11") {
+      because("Multiple vulnerabilities")
+    }
   }
   api(project(":query-service-api"))
   api("com.typesafe:config:1.4.1")


### PR DESCRIPTION
Runtime failure was due to missing "org.apache.log4j.Logger". This dependency was coming from zkclient. Added a constraint to user version "0.11" of zkclient to remove log4j dependency.