### PR TITLE
feat: add support for utilising text indexes if exits for like operator in pinot based handlers

### DIFF
--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/PinotColumnSpec.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/PinotColumnSpec.java
@@ -8,9 +8,11 @@ public class PinotColumnSpec {
 
   private final List<String> columnNames;
   private ValueType type;
+  private boolean textIndex;
 
   public PinotColumnSpec() {
     columnNames = new ArrayList<>();
+    textIndex = false;
   }
 
   public List<String> getColumnNames() {
@@ -27,5 +29,13 @@ public class PinotColumnSpec {
 
   public void setType(ValueType type) {
     this.type = type;
+  }
+
+  public boolean hasTextIndex() {
+    return textIndex;
+  }
+
+  public void setTextIndex() {
+    this.textIndex = true;
   }
 }

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
@@ -146,10 +146,8 @@ class QueryRequestToPinotSQLConverter {
       switch (filter.getOperator()) {
         case LIKE:
           /**
-           * If the text index is not enabled on lhs expression,
-           *  - the pql looks like `regexp_like(lhs, rhs)`
-           * else
-           *  - the pql looks like `text_match(lhs, rhs)`
+           * If the text index is not enabled on lhs expression, - the pql looks like
+           * `regexp_like(lhs, rhs)` else - the pql looks like `text_match(lhs, rhs)`
            */
           operator = handleLikeOperator(filter.getLhs());
           Expression rhs =
@@ -287,7 +285,7 @@ class QueryRequestToPinotSQLConverter {
 
   private String handleLikeOperator(Expression expression) {
     Optional<String> logicalColumnName = getLogicalColumnName(expression);
-    if(logicalColumnName.isPresent()
+    if (logicalColumnName.isPresent()
         && isSimpleAttributeExpression(expression)
         && viewDefinition.hasTextIndex(logicalColumnName.get())) {
       return TEXT_MATCH_OPERATOR;
@@ -296,7 +294,7 @@ class QueryRequestToPinotSQLConverter {
   }
 
   private Expression prefixValueForLikeOperator(String likeOperatorStr, Expression rhsExpression) {
-    if(likeOperatorStr.equals(TEXT_MATCH_OPERATOR)) {
+    if (likeOperatorStr.equals(TEXT_MATCH_OPERATOR)) {
       String strValue = "/" + rhsExpression.getLiteral().getValue().getString() + "/";
       Value value = Value.newBuilder().setValueType(ValueType.STRING).setString(strValue).build();
 

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
@@ -149,10 +149,10 @@ class QueryRequestToPinotSQLConverter {
            * If the text index is not enabled on lhs expression, - the pql looks like
            * `regexp_like(lhs, rhs)` else - the pql looks like `text_match(lhs, rhs)`
            */
-          operator = handleLikeOperator(filter.getLhs());
+          operator = handleLikeOperatorConversion(filter.getLhs());
           Expression rhs =
               handleValueConversionForLiteralExpression(filter.getLhs(), filter.getRhs());
-          rhs = prefixValueForLikeOperator(operator, rhs);
+          rhs = postProcessValueConversionForLikeOperator(operator, rhs);
 
           builder.append(operator);
           builder.append("(");
@@ -283,7 +283,7 @@ class QueryRequestToPinotSQLConverter {
     }
   }
 
-  private String handleLikeOperator(Expression expression) {
+  private String handleLikeOperatorConversion(Expression expression) {
     Optional<String> logicalColumnName = getLogicalColumnName(expression);
     if (logicalColumnName.isPresent()
         && isSimpleAttributeExpression(expression)
@@ -293,7 +293,8 @@ class QueryRequestToPinotSQLConverter {
     return REGEX_OPERATOR;
   }
 
-  private Expression prefixValueForLikeOperator(String likeOperatorStr, Expression rhsExpression) {
+  private Expression postProcessValueConversionForLikeOperator(
+      String likeOperatorStr, Expression rhsExpression) {
     if (likeOperatorStr.equals(TEXT_MATCH_OPERATOR)) {
       String strValue = "/" + rhsExpression.getLiteral().getValue().getString() + "/";
       Value value = Value.newBuilder().setValueType(ValueType.STRING).setString(strValue).build();

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/ViewDefinition.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/ViewDefinition.java
@@ -29,6 +29,7 @@ public class ViewDefinition {
   private static final String MAP_FIELDS_CONFIG_KEY = "mapFields";
   private static final String FILTERS_CONFIG_KEY = "filters";
   private static final String COLUMN_CONFIG_KEY = "column";
+  private static final String TEXT_INDEXES_FIELDS_CONFIG_KEY = "textIndexes";
 
   private static final long DEFAULT_RETENTION_TIME = TimeUnit.DAYS.toMillis(8);
   private static final long DEFAULT_TIME_GRANULARITY = TimeUnit.MINUTES.toMillis(1);
@@ -102,6 +103,13 @@ public class ViewDefinition {
                 ? config.getStringList(BYTES_FIELDS_CONFIG_KEY)
                 : List.of());
 
+    // get all the String fields that have enabled text Indexes
+    final Set<String> textIndexFields = new HashSet<>(
+        config.hasPath(TEXT_INDEXES_FIELDS_CONFIG_KEY)
+            ? config.getStringList(TEXT_INDEXES_FIELDS_CONFIG_KEY)
+            : List.of()
+    );
+
     Map<String, PinotColumnSpec> columnSpecMap = new HashMap<>();
     for (Map.Entry<String, String> entry : fieldMap.entrySet()) {
       String logicalName = entry.getKey();
@@ -120,6 +128,11 @@ public class ViewDefinition {
         spec.addColumnName(physName);
         spec.setType(ValueType.STRING);
       }
+
+      if (textIndexFields.contains(physName)) {
+        spec.setTextIndex();
+      }
+
       columnSpecMap.put(logicalName, spec);
     }
 
@@ -173,6 +186,10 @@ public class ViewDefinition {
 
   public ValueType getColumnType(String logicalName) {
     return columnSpecMap.get(logicalName).getType();
+  }
+
+  public boolean hasTextIndex(String logicalName) {
+    return columnSpecMap.get(logicalName).hasTextIndex();
   }
 
   public String getKeyColumnNameForMap(String logicalName) {

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/ViewDefinition.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/ViewDefinition.java
@@ -104,11 +104,11 @@ public class ViewDefinition {
                 : List.of());
 
     // get all the String fields that have enabled text Indexes
-    final Set<String> textIndexFields = new HashSet<>(
-        config.hasPath(TEXT_INDEXES_FIELDS_CONFIG_KEY)
-            ? config.getStringList(TEXT_INDEXES_FIELDS_CONFIG_KEY)
-            : List.of()
-    );
+    final Set<String> textIndexFields =
+        new HashSet<>(
+            config.hasPath(TEXT_INDEXES_FIELDS_CONFIG_KEY)
+                ? config.getStringList(TEXT_INDEXES_FIELDS_CONFIG_KEY)
+                : List.of());
 
     Map<String, PinotColumnSpec> columnSpecMap = new HashMap<>();
     for (Map.Entry<String, String> entry : fieldMap.entrySet()) {

--- a/query-service-impl/src/test/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverterTest.java
+++ b/query-service-impl/src/test/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverterTest.java
@@ -978,8 +978,8 @@ public class QueryRequestToPinotSQLConverterTest {
     defaultMockingForExecutionContext();
 
     /*
-    * select span_id, service_name from spaneventview where tenant_id = '__default' and ( start_time_millis > 1570658506605 and end_time_millis < 1570744906673 and regexp_like(service_name,'abc') ) limit 15
-    * */
+     * select span_id, service_name from spaneventview where tenant_id = '__default' and ( start_time_millis > 1570658506605 and end_time_millis < 1570744906673 and regexp_like(service_name,'abc') ) limit 15
+     * */
     assertPQLQuery(
         builder.build(),
         "select span_id, service_name from spanEventView "

--- a/query-service-impl/src/test/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverterTest.java
+++ b/query-service-impl/src/test/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverterTest.java
@@ -1005,14 +1005,14 @@ public class QueryRequestToPinotSQLConverterTest {
     Filter likeFilter =
         Filter.newBuilder()
             .setOperator(Operator.LIKE)
-            .setLhs(createColumnExpression("Span.attributes.response_body"))
+            .setLhs(createColumnExpression("Span.displaySpanName"))
             .setRhs(createStringLiteralValueExpression("abc"))
             .build();
     builder.setFilter(likeFilter);
 
     builder
         .addSelection(createColumnExpression("Span.id"))
-        .addSelection(createColumnExpression("Span.attributes.response_body"))
+        .addSelection(createColumnExpression("Span.displaySpanName"))
         .setFilter(createCompositeFilter(Operator.AND, startTimeFilter, endTimeFilter, likeFilter))
         .setLimit(15);
 
@@ -1021,7 +1021,7 @@ public class QueryRequestToPinotSQLConverterTest {
 
     assertPQLQuery(
         builder.build(),
-        "select span_id, response_body from spanEventView "
+        "select span_id, span_name from spanEventView "
             + "where "
             + viewDefinition.getTenantIdColumn()
             + " = '"
@@ -1030,7 +1030,7 @@ public class QueryRequestToPinotSQLConverterTest {
             + " and "
             + "( start_time_millis > 1570658506605 and end_time_millis < 1570744906673"
             + " and "
-            + "text_match(response_body,'/abc/') ) "
+            + "text_match(span_name,'/abc/') ) "
             + "limit 15",
         viewDefinition,
         executionContext);

--- a/query-service-impl/src/test/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverterTest.java
+++ b/query-service-impl/src/test/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverterTest.java
@@ -977,9 +977,6 @@ public class QueryRequestToPinotSQLConverterTest {
     ViewDefinition viewDefinition = getDefaultViewDefinition();
     defaultMockingForExecutionContext();
 
-    /*
-     * select span_id, service_name from spaneventview where tenant_id = '__default' and ( start_time_millis > 1570658506605 and end_time_millis < 1570744906673 and regexp_like(service_name,'abc') ) limit 15
-     * */
     assertPQLQuery(
         builder.build(),
         "select span_id, service_name from spanEventView "
@@ -1022,9 +1019,6 @@ public class QueryRequestToPinotSQLConverterTest {
     ViewDefinition viewDefinition = getDefaultViewDefinition();
     defaultMockingForExecutionContext();
 
-    /*
-     * select span_id, service_name from spaneventview where tenant_id = '__default' and ( start_time_millis > 1570658506605 and end_time_millis < 1570744906673 and regexp_like(service_name,'abc') ) limit 15
-     * */
     assertPQLQuery(
         builder.build(),
         "select span_id, response_body from spanEventView "

--- a/query-service-impl/src/test/resources/request_handler.conf
+++ b/query-service-impl/src/test/resources/request_handler.conf
@@ -8,6 +8,7 @@
       viewName = SpanEventView
       mapFields = ["tags", "request_headers"]
       bytesFields = ["parent_span_id", "span_id"]
+      textIndexes = ["response_body"]
       fieldMap = {
         "Span.tags": "tags",
         "Span.id": "span_id",

--- a/query-service-impl/src/test/resources/request_handler.conf
+++ b/query-service-impl/src/test/resources/request_handler.conf
@@ -8,7 +8,7 @@
       viewName = SpanEventView
       mapFields = ["tags", "request_headers"]
       bytesFields = ["parent_span_id", "span_id"]
-      textIndexes = ["response_body"]
+      textIndexes = ["span_name"]
       fieldMap = {
         "Span.tags": "tags",
         "Span.id": "span_id",


### PR DESCRIPTION
## Description
This PR add support for utilising text indexes for LIKE operator for pinot based request handler if the index for those column is enabled. So, the string column with index will translated to 
- text_match(column, /\<value\>/)

### Testing
- Added the request conversation test.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

