### PR TITLE
feat: extend the support for distinct count for multi-value

### DIFF
--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/converters/PinotFunctionConverter.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/converters/PinotFunctionConverter.java
@@ -20,7 +20,7 @@ import org.hypertrace.core.query.service.api.ValueType;
 
 public class PinotFunctionConverter {
   private static final String PINOT_CONCAT_FUNCTION = "CONCATSKIPNULL";
-  private static final String QUERY_FUNCTION_DISTINCTCOUNT_MV_INTERNAL = "DISTINCTCOUNTMV";
+  private static final String PINOT_DISTINCT_COUNT_MV_FUNCTION = "DISTINCTCOUNTMV";
 
   private static final String DEFAULT_AVG_RATE_SIZE = "PT1S";
   private final PinotFunctionConverterConfig config;
@@ -48,7 +48,7 @@ public class PinotFunctionConverter {
         return this.functionToStringForDistinctCount(function, argumentConverter);
       case QUERY_FUNCTION_CONCAT:
         return this.functionToString(this.toPinotConcat(function), argumentConverter);
-      case QUERY_FUNCTION_DISTINCTCOUNT_MV_INTERNAL:
+      case PINOT_DISTINCT_COUNT_MV_FUNCTION:
         return this.functionToStringForDistinctCountMv(function, argumentConverter);
       case QUERY_FUNCTION_AVGRATE:
         // AVGRATE not supported directly in Pinot. So AVG_RATE is computed by summing over all

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/converters/PinotFunctionConverter.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/converters/PinotFunctionConverter.java
@@ -78,13 +78,13 @@ public class PinotFunctionConverter {
   private String functionToStringForDistinctCount(
       Function function, java.util.function.Function<Expression, String> argumentConverter) {
     String columnName = argumentConverter.apply(function.getArgumentsList().get(0));
-    return this.config.getDistinctCountFunction(columnName) + "(" + columnName + ")";
+    return String.format("%s(%s)", this.config.getDistinctCountFunction(columnName), columnName);
   }
 
   private String functionToStringForDistinctCountMv(
       Function function, java.util.function.Function<Expression, String> argumentConverter) {
     String columnName = argumentConverter.apply(function.getArgumentsList().get(0));
-    return this.config.getDistinctCountMvFunction(columnName) + "(" + columnName + ")";
+    return String.format("%s(%s)", this.config.getDistinctCountMvFunction(columnName), columnName);
   }
 
   private String functionToStringForAvgRate(

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/converters/PinotFunctionConverter.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/converters/PinotFunctionConverter.java
@@ -20,6 +20,7 @@ import org.hypertrace.core.query.service.api.ValueType;
 
 public class PinotFunctionConverter {
   private static final String PINOT_CONCAT_FUNCTION = "CONCATSKIPNULL";
+  private static final String QUERY_FUNCTION_DISTINCTCOUNT_MV_INTERNAL = "DISTINCTCOUNTMV";
 
   private static final String DEFAULT_AVG_RATE_SIZE = "PT1S";
   private final PinotFunctionConverterConfig config;
@@ -47,6 +48,8 @@ public class PinotFunctionConverter {
         return this.functionToStringForDistinctCount(function, argumentConverter);
       case QUERY_FUNCTION_CONCAT:
         return this.functionToString(this.toPinotConcat(function), argumentConverter);
+      case QUERY_FUNCTION_DISTINCTCOUNT_MV_INTERNAL:
+        return this.functionToStringForDistinctCountMv(function, argumentConverter);
       case QUERY_FUNCTION_AVGRATE:
         // AVGRATE not supported directly in Pinot. So AVG_RATE is computed by summing over all
         // values and then dividing by a constant.
@@ -76,6 +79,12 @@ public class PinotFunctionConverter {
       Function function, java.util.function.Function<Expression, String> argumentConverter) {
     String columnName = argumentConverter.apply(function.getArgumentsList().get(0));
     return this.config.getDistinctCountFunction(columnName) + "(" + columnName + ")";
+  }
+
+  private String functionToStringForDistinctCountMv(
+      Function function, java.util.function.Function<Expression, String> argumentConverter) {
+    String columnName = argumentConverter.apply(function.getArgumentsList().get(0));
+    return this.config.getDistinctCountMvFunction(columnName) + "(" + columnName + ")";
   }
 
   private String functionToStringForAvgRate(

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/converters/PinotFunctionConverterConfig.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/converters/PinotFunctionConverterConfig.java
@@ -18,12 +18,16 @@ public class PinotFunctionConverterConfig {
   private static final String PERCENTILE_AGGREGATION_FUNCTION_CONFIG = "percentileAggFunction";
   private static final String DISTINCT_COUNT_AGGREGATION_FUNCTION_CONFIG =
       "distinctCountAggFunction";
+  private static final String DISTINCT_COUNT_MV_AGGREGATION_FUNCTION_CONFIG =
+      "distinctCountMvAggFunction";
   private static final String DISTINCT_COUNT_AGGREGATION_OVERRIDES = "distinctCountAggOverrides";
   private static final String DEFAULT_PERCENTILE_AGGREGATION_FUNCTION = "PERCENTILETDIGEST";
   private static final String DEFAULT_DISTINCT_COUNT_AGGREGATION_FUNCTION = "DISTINCTCOUNT";
+  private static final String DEFAULT_DISTINCT_COUNT_MV_AGGREGATION_FUNCTION = "DISTINCTCOUNTMV";
 
   String percentileAggregationFunction;
   String distinctCountAggregationFunction;
+  String distinctCountMvAggregationFunction;
   @Nonnull Map<String, String> distinctCountAggOverrides;
 
   public PinotFunctionConverterConfig(Config config) {
@@ -37,6 +41,12 @@ public class PinotFunctionConverterConfig {
           config.getString(DISTINCT_COUNT_AGGREGATION_FUNCTION_CONFIG);
     } else {
       this.distinctCountAggregationFunction = DEFAULT_DISTINCT_COUNT_AGGREGATION_FUNCTION;
+    }
+    if (config.hasPath(DISTINCT_COUNT_MV_AGGREGATION_FUNCTION_CONFIG)) {
+      this.distinctCountMvAggregationFunction =
+          config.getString(DISTINCT_COUNT_MV_AGGREGATION_FUNCTION_CONFIG);
+    } else {
+      this.distinctCountMvAggregationFunction = DEFAULT_DISTINCT_COUNT_MV_AGGREGATION_FUNCTION;
     }
     if (config.hasPath(DISTINCT_COUNT_AGGREGATION_OVERRIDES)) {
       Config overridesConfig = config.getConfig(DISTINCT_COUNT_AGGREGATION_OVERRIDES);
@@ -57,5 +67,10 @@ public class PinotFunctionConverterConfig {
   public String getDistinctCountFunction(String arg) {
     return Optional.ofNullable(distinctCountAggOverrides.get(arg))
         .orElse(distinctCountAggregationFunction);
+  }
+
+  public String getDistinctCountMvFunction(String arg) {
+    return Optional.ofNullable(distinctCountAggOverrides.get(arg))
+        .orElse(distinctCountMvAggregationFunction);
   }
 }


### PR DESCRIPTION
## Description
As part of this PR, we extend of support for using different aggregation function for distinct count query for multi value column.

Currently, we do support the same for single value field via below config at request handler level:
```
distinctCountAggFunction = DISTINCTCOUNTHLL
distinctCountAggOverrides = {
 "attribute_id_1" = DISTINCTCOUNT
}
```
It tells that, for all the single value attribute except `attribute_id_1` of the request handler, it will use `DISTINCTCOUNTHLL` function.

We are extending above as below:
```
distinctCountAggFunction = DISTINCTCOUNTHLL
distinctCountMvAggFunction = DISTINCTCOUNTHLLMV
distinctCountAggOverrides = {
 "attribute_id_1" = DISTINCTCOUNT
"attribute_mv_1" = DISTINCTCOUNT
}
```
The above config tells that,
- for all multi-value attribute except `attribute_id_1`, it will `DISTINCTCOUNTHLLMV` for distinct count
- for all single value attribute except `attribute_mv_1, it will use `DISTINCTCOUNTHLL` for distinct count


### Testing
Have added unit test.. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules


