### PR TITLE
fix: adds values filter for map column

### DIFF
--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
@@ -203,7 +203,7 @@ class QueryRequestToPinotSQLConverter {
           break;
         default:
           rhs = handleValueConversionForLiteralExpression(filter.getLhs(), filter.getRhs());
-          applyValueFilterForMapColumn(filter, paramsBuilder, executionContext, builder, rhs);
+          applyValuesFilterForMapColumn(filter, paramsBuilder, executionContext, builder, rhs);
           builder.append(
               convertExpressionToString(filter.getLhs(), paramsBuilder, executionContext));
           builder.append(" ");
@@ -225,7 +225,7 @@ class QueryRequestToPinotSQLConverter {
    * CONTAINS_KEYVALUE, we also added the "__values" filter. By including this additional filter, if
    * there is an inverted index on a map field, it can be utilized to improve performance.
    */
-  private void applyValueFilterForMapColumn(
+  private void applyValuesFilterForMapColumn(
       Filter filter,
       Builder paramsBuilder,
       ExecutionContext executionContext,

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
@@ -203,12 +203,7 @@ class QueryRequestToPinotSQLConverter {
           break;
         default:
           rhs = handleValueConversionForLiteralExpression(filter.getLhs(), filter.getRhs());
-
-          Optional<String> valueFilter =
-              getValuesFilterForMapColumn(
-                  filter.getLhs(), rhs, filter.getOperator(), paramsBuilder, executionContext);
-          valueFilter.stream().forEach(str -> builder.append(str));
-
+          applyValueFilterForMapColumn(filter, paramsBuilder, executionContext, builder, rhs);
           builder.append(
               convertExpressionToString(filter.getLhs(), paramsBuilder, executionContext));
           builder.append(" ");
@@ -230,22 +225,33 @@ class QueryRequestToPinotSQLConverter {
    * CONTAINS_KEYVALUE, we also added the "__values" filter. By including this additional filter, if
    * there is an inverted index on a map field, it can be utilized to improve performance.
    */
-  private Optional<String> getValuesFilterForMapColumn(
-      Expression lhs,
-      Expression rhs,
-      Operator operator,
+  private void applyValueFilterForMapColumn(
+      Filter filter,
       Builder paramsBuilder,
-      ExecutionContext executionContext) {
-    if (isAttributeExpressionWithSubpath(lhs) && operator.equals(Operator.EQ)) {
-      String valCol = convertExpressionToMapValueColumn(lhs);
-      return Optional.of(
-          String.format(
-              "%s %s %s AND ",
-              valCol,
-              convertOperatorToString(Operator.EQ),
-              convertExpressionToString(rhs, paramsBuilder, executionContext)));
+      ExecutionContext executionContext,
+      StringBuilder builder,
+      Expression rhs) {
+    if (isAttributeExpressionWithSubpath(filter.getLhs())
+        && filter.getOperator().equals(Operator.EQ)) {
+      String valueFilter =
+          getValuesFilterForMapColumn(filter.getLhs(), rhs, paramsBuilder, executionContext);
+      builder.append(valueFilter);
+      builder.append(" AND ");
     }
-    return Optional.empty();
+  }
+
+  /**
+   * This helper method constructs a "__values" filter for a map column. For example, if the map
+   * column is called "tags", it returns "tags__VALUES = 'value'".
+   */
+  private String getValuesFilterForMapColumn(
+      Expression lhs, Expression rhs, Builder paramsBuilder, ExecutionContext executionContext) {
+    String valCol = convertExpressionToMapValueColumn(lhs);
+    return String.format(
+        "%s %s %s",
+        valCol,
+        convertOperatorToString(Operator.EQ),
+        convertExpressionToString(rhs, paramsBuilder, executionContext));
   }
   /**
    * Handles value conversion of a literal expression based on its associated column.

--- a/query-service-impl/src/test/java/org/hypertrace/core/query/service/pinot/MigrationTest.java
+++ b/query-service-impl/src/test/java/org/hypertrace/core/query/service/pinot/MigrationTest.java
@@ -406,7 +406,7 @@ public class MigrationTest {
             + " = '"
             + TENANT_ID
             + "' "
-            + "AND ( tags__keys = 'flags' and mapvalue(tags__keys,'flags',tags__values) = '0' )",
+            + "AND ( tags__keys = 'flags' and tags__values = '0' and mapvalue(tags__keys,'flags',tags__values) = '0' )",
         viewDefinition,
         executionContext);
   }


### PR DESCRIPTION
## Description
This pull request introduces an additional value filter for map columns, aiming to enhance performance by utilizing the underlying inverted index on the `__keys` and `__values` columns of the Pinot implementation.

This optimisation is specifically applied to queries like `mapValue(tags__keys, 'flags', tags__values) = '0'`.

This approach is the same as the one followed in the deprecated `CONTAINS_KEYVALUE`.
Ref: https://github.com/hypertrace/query-service/blob/b89ebf416e876959586d47f8e67f126be239c7d5/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java#L181

### Testing
Modified the existing test case.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

