### PR TITLE
ENG-35614: add support for bytes type in Trino handler

### DIFF
--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/trino/converters/DefaultColumnRequestConverter.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/trino/converters/DefaultColumnRequestConverter.java
@@ -360,6 +360,9 @@ class DefaultColumnRequestConverter implements ColumnRequestConverter {
         trinoExecutionContext.addActualTableColumnName(columnName);
         ColumnRequestContext context = trinoExecutionContext.getColumnRequestContext();
         context.setColumnValueType(tableDefinition.getColumnType(logicalColumnName));
+        if (context.isBytesColumnType()) {
+          return String.format("lower(to_hex(%s))", columnName);
+        }
         return columnName;
       case LITERAL:
         return convertLiteralToString(expression.getLiteral(), paramsBuilder);

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/trino/converters/DefaultColumnRequestConverter.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/trino/converters/DefaultColumnRequestConverter.java
@@ -188,8 +188,6 @@ class DefaultColumnRequestConverter implements ColumnRequestConverter {
     }
 
     String convertedLiteral = convertLiteralToString(rhs.getLiteral(), paramsBuilder);
-    // add decode for all string values
-    convertedLiteral = convertedLiteral.replace("?", "decode(?, 'hex')");
 
     builder.append(lhs);
     builder.append(" ");

--- a/query-service-impl/src/test/java/org/hypertrace/core/query/service/trino/QueryRequestToTrinoSQLConverterTest.java
+++ b/query-service-impl/src/test/java/org/hypertrace/core/query/service/trino/QueryRequestToTrinoSQLConverterTest.java
@@ -83,7 +83,7 @@ class QueryRequestToTrinoSQLConverterTest {
 
     assertSQLQuery(
         builder.build(),
-        "select span_id, tags, request_headers "
+        "select lower(to_hex(span_id)), tags, request_headers "
             + "FROM span-event-view "
             + "where "
             + tableDefinition.getTenantIdColumn()
@@ -104,7 +104,7 @@ class QueryRequestToTrinoSQLConverterTest {
 
     assertSQLQuery(
         builder.build(),
-        "Select span_id FROM span-event-view "
+        "Select lower(to_hex(span_id)) FROM span-event-view "
             + "where "
             + tableDefinition.getTenantIdColumn()
             + " = '"
@@ -123,7 +123,7 @@ class QueryRequestToTrinoSQLConverterTest {
 
     assertSQLQuery(
         builder.build(),
-        "Select distinct span_id FROM span-event-view "
+        "Select distinct lower(to_hex(span_id)) FROM span-event-view "
             + "where "
             + tableDefinition.getTenantIdColumn()
             + " = '"
@@ -146,7 +146,7 @@ class QueryRequestToTrinoSQLConverterTest {
 
     assertSQLQuery(
         builder.build(),
-        "Select distinct span_id, span_name, service_name FROM span-event-view "
+        "Select distinct lower(to_hex(span_id)), span_name, service_name FROM span-event-view "
             + "where "
             + tableDefinition.getTenantIdColumn()
             + " = '"
@@ -165,7 +165,7 @@ class QueryRequestToTrinoSQLConverterTest {
 
     assertSQLQuery(
         queryRequest,
-        "Select span_id FROM span-event-view "
+        "Select lower(to_hex(span_id)) FROM span-event-view "
             + "WHERE "
             + tableDefinition.getTenantIdColumn()
             + " = '"
@@ -208,7 +208,7 @@ class QueryRequestToTrinoSQLConverterTest {
 
     assertSQLQuery(
         queryRequest,
-        "Select span_id FROM span-event-view WHERE "
+        "Select lower(to_hex(span_id)) FROM span-event-view WHERE "
             + tableDefinition.getTenantIdColumn()
             + " = '"
             + TENANT_ID
@@ -246,7 +246,7 @@ class QueryRequestToTrinoSQLConverterTest {
 
     assertSQLQuery(
         queryRequest,
-        "Select span_id FROM span-event-view WHERE "
+        "Select lower(to_hex(span_id)) FROM span-event-view WHERE "
             + tableDefinition.getTenantIdColumn()
             + " = '"
             + TENANT_ID
@@ -265,7 +265,7 @@ class QueryRequestToTrinoSQLConverterTest {
 
     assertSQLQuery(
         queryRequest,
-        "Select span_id FROM span-event-view WHERE "
+        "Select lower(to_hex(span_id)) FROM span-event-view WHERE "
             + tableDefinition.getTenantIdColumn()
             + " = '"
             + TENANT_ID
@@ -285,7 +285,7 @@ class QueryRequestToTrinoSQLConverterTest {
 
     assertSQLQuery(
         queryRequest,
-        "Select span_id FROM span-event-view WHERE "
+        "Select lower(to_hex(span_id)) FROM span-event-view WHERE "
             + tableDefinition.getTenantIdColumn()
             + " = '"
             + TENANT_ID

--- a/query-service-impl/src/test/java/org/hypertrace/core/query/service/trino/QueryRequestToTrinoSQLConverterTest.java
+++ b/query-service-impl/src/test/java/org/hypertrace/core/query/service/trino/QueryRequestToTrinoSQLConverterTest.java
@@ -707,7 +707,7 @@ class QueryRequestToTrinoSQLConverterTest {
         executionContext);
   }
 
-  // @Test
+  @Test
   void testQueryWithBytesColumnWithInValidId() {
     Builder builder = QueryRequest.newBuilder();
     builder.addSelection(createColumnExpression("Span.id").build());
@@ -722,7 +722,7 @@ class QueryRequestToTrinoSQLConverterTest {
     assertExceptionOnSQLQuery(
         builder.build(),
         IllegalArgumentException.class,
-        "Invalid input:{ 042e5523ff6b250L" + " } for bytes column:{ parent_span_id }");
+        "Invalid input:{ 042e5523ff6b250L" + " } for bytes column:{ lower(to_hex(parent_span_id)) }");
   }
 
   @Test

--- a/query-service-impl/src/test/java/org/hypertrace/core/query/service/trino/QueryRequestToTrinoSQLConverterTest.java
+++ b/query-service-impl/src/test/java/org/hypertrace/core/query/service/trino/QueryRequestToTrinoSQLConverterTest.java
@@ -722,7 +722,8 @@ class QueryRequestToTrinoSQLConverterTest {
     assertExceptionOnSQLQuery(
         builder.build(),
         IllegalArgumentException.class,
-        "Invalid input:{ 042e5523ff6b250L" + " } for bytes column:{ lower(to_hex(parent_span_id)) }");
+        "Invalid input:{ 042e5523ff6b250L"
+            + " } for bytes column:{ lower(to_hex(parent_span_id)) }");
   }
 
   @Test

--- a/query-service-impl/src/test/java/org/hypertrace/core/query/service/trino/QueryRequestToTrinoSQLConverterTest.java
+++ b/query-service-impl/src/test/java/org/hypertrace/core/query/service/trino/QueryRequestToTrinoSQLConverterTest.java
@@ -455,7 +455,7 @@ class QueryRequestToTrinoSQLConverterTest {
         executionContext);
   }
 
-  // @Test
+  @Test
   void testQueryWithStringArray() {
     Builder builder = QueryRequest.newBuilder();
     builder.addSelection(createColumnExpression("Span.id").build());
@@ -470,19 +470,18 @@ class QueryRequestToTrinoSQLConverterTest {
 
     assertSQLQuery(
         builder.build(),
-        "SELECT encode(span_id, 'hex') FROM public.\"span-event-view\" "
+        "SELECT lower(to_hex(span_id)) FROM span-event-view "
             + "WHERE "
             + tableDefinition.getTenantIdColumn()
             + " = '"
             + TENANT_ID
             + "' "
-            + "AND span_id IN ("
-            + "decode('"
+            + "AND lower(to_hex(span_id)) IN "
+            + "('"
             + spanId1
-            + "', 'hex'), "
-            + "decode('"
+            + "', '"
             + spanId2
-            + "', 'hex'))",
+            + "')",
         tableDefinition,
         executionContext);
   }
@@ -679,7 +678,7 @@ class QueryRequestToTrinoSQLConverterTest {
         executionContext);
   }
 
-  // @Test
+  @Test
   void testQueryWithBytesColumnWithValidId() {
     Builder builder = QueryRequest.newBuilder();
     builder.addSelection(createColumnExpression("Span.id").build());
@@ -697,13 +696,13 @@ class QueryRequestToTrinoSQLConverterTest {
 
     assertSQLQuery(
         request,
-        "SELECT encode(span_id, 'hex') FROM public.\"span-event-view\" "
+        "SELECT lower(to_hex(span_id)) FROM span-event-view "
             + "WHERE "
             + tableDefinition.getTenantIdColumn()
             + " = '"
             + TENANT_ID
             + "' "
-            + "AND ( parent_span_id = decode('042e5523ff6b2506', 'hex') ) limit 5",
+            + "AND ( lower(to_hex(parent_span_id)) = '042e5523ff6b2506' ) limit 5",
         tableDefinition,
         executionContext);
   }
@@ -726,7 +725,7 @@ class QueryRequestToTrinoSQLConverterTest {
         "Invalid input:{ 042e5523ff6b250L" + " } for bytes column:{ parent_span_id }");
   }
 
-  // @Test
+  @Test
   void testQueryWithBytesColumnWithNullId() {
     Builder builder = QueryRequest.newBuilder();
     builder.addSelection(createColumnExpression("Span.id").build());
@@ -743,18 +742,18 @@ class QueryRequestToTrinoSQLConverterTest {
 
     assertSQLQuery(
         request,
-        "SELECT encode(span_id, 'hex') FROM public.\"span-event-view\" "
+        "SELECT lower(to_hex(span_id)) FROM span-event-view "
             + "WHERE "
             + tableDefinition.getTenantIdColumn()
             + " = '"
             + TENANT_ID
             + "' "
-            + "AND ( parent_span_id != '' ) limit 5",
+            + "AND ( lower(to_hex(parent_span_id)) != '' ) limit 5",
         tableDefinition,
         executionContext);
   }
 
-  // @Test
+  @Test
   void testQueryWithBytesColumnWithEmptyId() {
     Builder builder = QueryRequest.newBuilder();
     builder.addSelection(createColumnExpression("Span.id").build());
@@ -771,18 +770,18 @@ class QueryRequestToTrinoSQLConverterTest {
 
     assertSQLQuery(
         request,
-        "SELECT encode(span_id, 'hex') FROM public.\"span-event-view\" "
+        "SELECT lower(to_hex(span_id)) FROM span-event-view "
             + "WHERE "
             + tableDefinition.getTenantIdColumn()
             + " = '"
             + TENANT_ID
             + "' "
-            + "AND ( parent_span_id != '' ) limit 5",
+            + "AND ( lower(to_hex(parent_span_id)) != '' ) limit 5",
         tableDefinition,
         executionContext);
   }
 
-  // @Test
+  @Test
   void testQueryWithBytesColumnInFilter() {
     Builder builder = QueryRequest.newBuilder();
     builder.addSelection(createColumnExpression("Span.metrics.duration_millis"));
@@ -795,13 +794,13 @@ class QueryRequestToTrinoSQLConverterTest {
 
     assertSQLQuery(
         builder.build(),
-        "SELECT duration_millis FROM public.\"span-event-view\" "
+        "SELECT duration_millis FROM span-event-view "
             + "WHERE "
             + tableDefinition.getTenantIdColumn()
             + " = '"
             + TENANT_ID
             + "' "
-            + "AND span_id in (decode('042e5523ff6b2506', 'hex'))",
+            + "AND lower(to_hex(span_id)) in ('042e5523ff6b2506')",
         tableDefinition,
         executionContext);
   }


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
