### PR TITLE
add support for delegating query to Trino handler based on isTrino attribute

### DIFF
--- a/owasp-suppressions.xml
+++ b/owasp-suppressions.xml
@@ -39,7 +39,7 @@
     <notes><![CDATA[
    file name: netty-handler-4.1.94.Final.jar
    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/io\.netty/netty\-handler@.*$</packageUrl>
+    <packageUrl regex="true">^pkg:maven/io\.netty/netty.*@.*$</packageUrl>
     <vulnerabilityName>CVE-2023-4586</vulnerabilityName>
   </suppress>
 </suppressions>

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/trino/QueryRequestToTrinoSQLConverter.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/trino/QueryRequestToTrinoSQLConverter.java
@@ -63,11 +63,13 @@ class QueryRequestToTrinoSQLConverter {
     trinoExecutionContext.clearActualTableColumnNames();
 
     paramsBuilder.addStringParam(trinoExecutionContext.getExecutionContext().getTenantId());
-    Filter filter = trinoFilterHandler.skipTrinoAttributeFilter(request.getFilter());
-    if (!filter.equals(Filter.getDefaultInstance())) {
-      String filterClause =
-          columnRequestConverter.convertFilterClause(filter, paramsBuilder, trinoExecutionContext);
-      trinoExecutionContext.addResolvedFilterColumnQuery(filterClause);
+    if (request.hasFilter()) {
+      Filter filter = trinoFilterHandler.skipTrinoAttributeFilter(request.getFilter());
+      if (!filter.equals(Filter.getDefaultInstance())) {
+        String filterClause =
+            columnRequestConverter.convertFilterClause(filter, paramsBuilder, trinoExecutionContext);
+        trinoExecutionContext.addResolvedFilterColumnQuery(filterClause);
+      }
     }
     trinoExecutionContext.addAllFilterTableColumnNames(
         trinoExecutionContext.getActualTableColumnNames());

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/trino/QueryRequestToTrinoSQLConverter.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/trino/QueryRequestToTrinoSQLConverter.java
@@ -67,7 +67,8 @@ class QueryRequestToTrinoSQLConverter {
       Filter filter = trinoFilterHandler.skipTrinoAttributeFilter(request.getFilter());
       if (!filter.equals(Filter.getDefaultInstance())) {
         String filterClause =
-            columnRequestConverter.convertFilterClause(filter, paramsBuilder, trinoExecutionContext);
+            columnRequestConverter.convertFilterClause(
+                filter, paramsBuilder, trinoExecutionContext);
         trinoExecutionContext.addResolvedFilterColumnQuery(filterClause);
       }
     }

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/trino/TrinoBasedRequestHandler.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/trino/TrinoBasedRequestHandler.java
@@ -43,6 +43,7 @@ public class TrinoBasedRequestHandler implements RequestHandler {
   private static final String START_TIME_ATTRIBUTE_NAME_CONFIG_KEY = "startTimeAttributeName";
   private static final String SLOW_QUERY_THRESHOLD_MS_CONFIG = "slowQueryThresholdMs";
   private static final String MIN_REQUEST_DURATION_KEY = "minRequestDuration";
+  private static final String IS_TRINO_ATTRIBUTE = "Event.isTrino";
 
   private static final int DEFAULT_SLOW_QUERY_THRESHOLD_MS = 3000;
   private static final Set<Operator> GTE_OPERATORS = Set.of(Operator.GE, Operator.GT, Operator.EQ);
@@ -67,6 +68,7 @@ public class TrinoBasedRequestHandler implements RequestHandler {
   private Optional<String> startTimeAttributeName;
   private QueryRequestToTrinoSQLConverter request2TrinoSqlConverter;
   private final TrinoClientFactory trinoClientFactory;
+  private final TrinoFilterHandler trinoFilterHandler;
 
   private final JsonFormat.Printer protoJsonPrinter =
       JsonFormat.printer().omittingInsignificantWhitespace();
@@ -79,6 +81,7 @@ public class TrinoBasedRequestHandler implements RequestHandler {
     this.name = name;
     this.trinoClientFactory = trinoClientFactory;
     this.processConfig(config);
+    this.trinoFilterHandler = new TrinoFilterHandler();
   }
 
   @Override
@@ -96,7 +99,16 @@ public class TrinoBasedRequestHandler implements RequestHandler {
     Set<String> referencedColumns = executionContext.getReferencedColumns();
 
     Preconditions.checkArgument(!referencedColumns.isEmpty());
+
+    // query must contain isTrino attribute filter
+    if (!trinoFilterHandler.containsAttributeFilter(request)) {
+      return QueryCost.UNSUPPORTED;
+    }
+
     for (String referencedColumn : referencedColumns) {
+      if (referencedColumn.equals(IS_TRINO_ATTRIBUTE)) {
+        continue;
+      }
       if (!tableDefinition.containsColumn(referencedColumn)) {
         return QueryCost.UNSUPPORTED;
       }

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/trino/TrinoFilterHandler.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/trino/TrinoFilterHandler.java
@@ -1,14 +1,11 @@
 package org.hypertrace.core.query.service.trino;
 
 import static org.hypertrace.core.query.service.QueryRequestUtil.getLogicalColumnName;
-import static org.hypertrace.core.query.service.api.Expression.ValueCase.LITERAL;
 
 import java.util.List;
 import java.util.Optional;
 import org.hypertrace.core.query.service.api.Filter;
-import org.hypertrace.core.query.service.api.LiteralConstant;
 import org.hypertrace.core.query.service.api.QueryRequest;
-import org.hypertrace.core.query.service.api.ValueType;
 
 public class TrinoFilterHandler {
   private static final String IS_TRINO_ATTRIBUTE = "Event.isTrino";
@@ -54,18 +51,8 @@ public class TrinoFilterHandler {
   }
 
   private boolean isTrinoAttributeFilter(Filter filter) {
-    // filter must be of the form: isTrino = true
+    // filter must contain Event.isTrino attribute
     Optional<String> mayBeColumn = getLogicalColumnName(filter.getLhs());
-    if (mayBeColumn.isPresent()) {
-      if (mayBeColumn.get().equals(IS_TRINO_ATTRIBUTE)) {
-        if (filter.getRhs().getValueCase() == LITERAL) {
-          LiteralConstant value = filter.getRhs().getLiteral();
-          if (value.getValue().getValueType() == ValueType.BOOL) {
-            return value.getValue().getBoolean();
-          }
-        }
-      }
-    }
-    return false;
+    return mayBeColumn.isPresent() && mayBeColumn.get().equals(IS_TRINO_ATTRIBUTE);
   }
 }

--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/trino/TrinoFilterHandler.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/trino/TrinoFilterHandler.java
@@ -1,0 +1,71 @@
+package org.hypertrace.core.query.service.trino;
+
+import static org.hypertrace.core.query.service.QueryRequestUtil.getLogicalColumnName;
+import static org.hypertrace.core.query.service.api.Expression.ValueCase.LITERAL;
+
+import java.util.List;
+import java.util.Optional;
+import org.hypertrace.core.query.service.api.Filter;
+import org.hypertrace.core.query.service.api.LiteralConstant;
+import org.hypertrace.core.query.service.api.QueryRequest;
+import org.hypertrace.core.query.service.api.ValueType;
+
+public class TrinoFilterHandler {
+  private static final String IS_TRINO_ATTRIBUTE = "Event.isTrino";
+
+  public boolean containsAttributeFilter(QueryRequest request) {
+    return request.hasFilter() && containsAttributeFilter(request.getFilter());
+  }
+
+  public Filter skipTrinoAttributeFilter(Filter filter) {
+    return skipAttributeFilterIfPresent(filter);
+  }
+
+  private boolean containsAttributeFilter(Filter filter) {
+    if (filter.getChildFilterCount() > 0) {
+      for (Filter childFilter : filter.getChildFilterList()) {
+        if (containsAttributeFilter(childFilter)) {
+          return true;
+        }
+      }
+    }
+    return isTrinoAttributeFilter(filter);
+  }
+
+  private Filter skipAttributeFilterIfPresent(Filter filter) {
+    if (filter.getChildFilterCount() > 0) {
+      Filter.Builder builder = filter.toBuilder();
+      List<Filter> childFilters = filter.getChildFilterList();
+      builder.clearChildFilter();
+      for (Filter childFilter : childFilters) {
+        Filter skippedFilter = skipAttributeFilterIfPresent(childFilter);
+        if (!skippedFilter.equals(Filter.getDefaultInstance())) {
+          builder.addChildFilter(skippedFilter);
+        }
+      }
+      if (builder.getChildFilterList().isEmpty()) {
+        return Filter.getDefaultInstance();
+      }
+      return builder.build();
+    } else if (isTrinoAttributeFilter(filter)) {
+      return Filter.getDefaultInstance();
+    }
+    return filter;
+  }
+
+  private boolean isTrinoAttributeFilter(Filter filter) {
+    // filter must be of the form: isTrino = true
+    Optional<String> mayBeColumn = getLogicalColumnName(filter.getLhs());
+    if (mayBeColumn.isPresent()) {
+      if (mayBeColumn.get().equals(IS_TRINO_ATTRIBUTE)) {
+        if (filter.getRhs().getValueCase() == LITERAL) {
+          LiteralConstant value = filter.getRhs().getLiteral();
+          if (value.getValue().getValueType() == ValueType.BOOL) {
+            return value.getValue().getBoolean();
+          }
+        }
+      }
+    }
+    return false;
+  }
+}

--- a/query-service-impl/src/test/java/org/hypertrace/core/query/service/trino/QueryRequestToTrinoSQLConverterTest.java
+++ b/query-service-impl/src/test/java/org/hypertrace/core/query/service/trino/QueryRequestToTrinoSQLConverterTest.java
@@ -217,6 +217,48 @@ class QueryRequestToTrinoSQLConverterTest {
         executionContext);
   }
 
+  @Test
+  void testQueryWithIsTrinoFilter() {
+    QueryRequest queryRequest =
+        buildSimpleQueryWithFilter(createEqualsFilter("Event.isTrino", true));
+    TableDefinition tableDefinition = getDefaultTableDefinition();
+    defaultMockingForExecutionContext();
+
+    assertSQLQuery(
+        queryRequest,
+        "Select lower(to_hex(span_id)) FROM span-event-view WHERE "
+            + tableDefinition.getTenantIdColumn()
+            + " = '"
+            + TENANT_ID
+            + "'",
+        tableDefinition,
+        executionContext);
+  }
+
+  @Test
+  void testQueryWithMultipleFiltersAndIsTrinoFilter() {
+    Filter isEntryFilter = createEqualsFilter("Span.is_entry", true);
+    Filter isTrinoFilter = createEqualsFilter("Event.isTrino", true);
+    Filter isBareFilter = createEqualsFilter("Span.isBare", false);
+    QueryRequest queryRequest =
+        buildSimpleQueryWithFilter(
+            createCompositeFilter(Operator.AND, isEntryFilter, isTrinoFilter, isBareFilter)
+                .build());
+    TableDefinition tableDefinition = getDefaultTableDefinition();
+    defaultMockingForExecutionContext();
+
+    assertSQLQuery(
+        queryRequest,
+        "Select lower(to_hex(span_id)) FROM span-event-view WHERE "
+            + tableDefinition.getTenantIdColumn()
+            + " = '"
+            + TENANT_ID
+            + "' "
+            + "AND ( is_entry = true AND is_bare = false )",
+        tableDefinition,
+        executionContext);
+  }
+
   // @Test
   void testQueryWithDoubleFilter() {
     QueryRequest queryRequest =

--- a/query-service-impl/src/test/java/org/hypertrace/core/query/service/trino/QueryRequestToTrinoSQLConverterTest.java
+++ b/query-service-impl/src/test/java/org/hypertrace/core/query/service/trino/QueryRequestToTrinoSQLConverterTest.java
@@ -218,7 +218,7 @@ class QueryRequestToTrinoSQLConverterTest {
   }
 
   @Test
-  void testQueryWithIsTrinoFilter() {
+  void testQueryWithIsTrinoFilterOnly() {
     QueryRequest queryRequest =
         buildSimpleQueryWithFilter(createEqualsFilter("Event.isTrino", true));
     TableDefinition tableDefinition = getDefaultTableDefinition();
@@ -236,10 +236,58 @@ class QueryRequestToTrinoSQLConverterTest {
   }
 
   @Test
-  void testQueryWithMultipleFiltersAndIsTrinoFilter() {
+  void testQueryWithIsTrinoFilterInBeginning() {
+    Filter isTrinoFilter = createEqualsFilter("Event.isTrino", true);
+    Filter isEntryFilter = createEqualsFilter("Span.is_entry", true);
+    Filter isBareFilter = createEqualsFilter("Span.isBare", false);
+    QueryRequest queryRequest =
+        buildSimpleQueryWithFilter(
+            createCompositeFilter(Operator.AND, isEntryFilter, isTrinoFilter, isBareFilter)
+                .build());
+    TableDefinition tableDefinition = getDefaultTableDefinition();
+    defaultMockingForExecutionContext();
+
+    assertSQLQuery(
+        queryRequest,
+        "Select lower(to_hex(span_id)) FROM span-event-view WHERE "
+            + tableDefinition.getTenantIdColumn()
+            + " = '"
+            + TENANT_ID
+            + "' "
+            + "AND ( is_entry = true AND is_bare = false )",
+        tableDefinition,
+        executionContext);
+  }
+
+  @Test
+  void testQueryWithIsTrinoFilterInMiddle() {
     Filter isEntryFilter = createEqualsFilter("Span.is_entry", true);
     Filter isTrinoFilter = createEqualsFilter("Event.isTrino", true);
     Filter isBareFilter = createEqualsFilter("Span.isBare", false);
+    QueryRequest queryRequest =
+        buildSimpleQueryWithFilter(
+            createCompositeFilter(Operator.AND, isEntryFilter, isTrinoFilter, isBareFilter)
+                .build());
+    TableDefinition tableDefinition = getDefaultTableDefinition();
+    defaultMockingForExecutionContext();
+
+    assertSQLQuery(
+        queryRequest,
+        "Select lower(to_hex(span_id)) FROM span-event-view WHERE "
+            + tableDefinition.getTenantIdColumn()
+            + " = '"
+            + TENANT_ID
+            + "' "
+            + "AND ( is_entry = true AND is_bare = false )",
+        tableDefinition,
+        executionContext);
+  }
+
+  @Test
+  void testQueryWithIsTrinoFilterInEnd() {
+    Filter isEntryFilter = createEqualsFilter("Span.is_entry", true);
+    Filter isBareFilter = createEqualsFilter("Span.isBare", false);
+    Filter isTrinoFilter = createEqualsFilter("Event.isTrino", true);
     QueryRequest queryRequest =
         buildSimpleQueryWithFilter(
             createCompositeFilter(Operator.AND, isEntryFilter, isTrinoFilter, isBareFilter)

--- a/query-service-impl/src/test/java/org/hypertrace/core/query/service/trino/QueryRequestToTrinoSQLConverterTest.java
+++ b/query-service-impl/src/test/java/org/hypertrace/core/query/service/trino/QueryRequestToTrinoSQLConverterTest.java
@@ -242,7 +242,7 @@ class QueryRequestToTrinoSQLConverterTest {
     Filter isBareFilter = createEqualsFilter("Span.isBare", false);
     QueryRequest queryRequest =
         buildSimpleQueryWithFilter(
-            createCompositeFilter(Operator.AND, isEntryFilter, isTrinoFilter, isBareFilter)
+            createCompositeFilter(Operator.AND, isTrinoFilter, isEntryFilter, isBareFilter)
                 .build());
     TableDefinition tableDefinition = getDefaultTableDefinition();
     defaultMockingForExecutionContext();
@@ -290,7 +290,7 @@ class QueryRequestToTrinoSQLConverterTest {
     Filter isTrinoFilter = createEqualsFilter("Event.isTrino", true);
     QueryRequest queryRequest =
         buildSimpleQueryWithFilter(
-            createCompositeFilter(Operator.AND, isEntryFilter, isTrinoFilter, isBareFilter)
+            createCompositeFilter(Operator.AND, isEntryFilter, isBareFilter, isTrinoFilter)
                 .build());
     TableDefinition tableDefinition = getDefaultTableDefinition();
     defaultMockingForExecutionContext();


### PR DESCRIPTION

## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
