### PR TITLE
chore: added array column tests in pinot

### DIFF
--- a/query-service-impl/src/test/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverterTest.java
+++ b/query-service-impl/src/test/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverterTest.java
@@ -540,6 +540,32 @@ public class QueryRequestToPinotSQLConverterTest {
   }
 
   @Test
+  void testQueryWithArrayColumnInFilter() {
+    Builder builder = QueryRequest.newBuilder();
+    builder.addSelection(createColumnExpression("Span.id").build());
+
+    Filter filter = createInFilter("Span.ip_types", List.of("Public Proxy", "Bot"));
+    builder.setFilter(filter);
+    builder.setLimit(5);
+
+    QueryRequest request = builder.build();
+    ViewDefinition viewDefinition = getDefaultViewDefinition();
+    defaultMockingForExecutionContext();
+
+    assertPQLQuery(
+        request,
+        "select span_id from spaneventview "
+            + "WHERE "
+            + viewDefinition.getTenantIdColumn()
+            + " = '"
+            + TENANT_ID
+            + "' "
+            + "and ip_types in ('public proxy', 'bot') limit 5",
+        viewDefinition,
+        executionContext);
+  }
+
+  @Test
   public void testQueryWithLikeOperator() {
     Builder builder = QueryRequest.newBuilder();
     Expression spanId = createColumnExpression("Span.id").build();

--- a/query-service-impl/src/test/resources/request_handler.conf
+++ b/query-service-impl/src/test/resources/request_handler.conf
@@ -9,6 +9,7 @@
       mapFields = ["tags", "request_headers"]
       bytesFields = ["parent_span_id", "span_id"]
       textIndexes = ["span_name"]
+      arrayFields = ["ip_types"]
       fieldMap = {
         "Span.tags": "tags",
         "Span.id": "span_id",
@@ -24,7 +25,8 @@
         "Span.attributes.response_body": "response_body",
         "Span.metrics.duration_millis": "duration_millis",
         "Span.serviceName": "service_name",
-        "Span.attributes.parent_span_id": "parent_span_id"
+        "Span.attributes.parent_span_id": "parent_span_id",
+        "Span.ip_types": "ip_types"
       }
     }
   }


### PR DESCRIPTION
This PR : https://github.com/hypertrace/query-service/pull/201/files provides tests for Array Column filters. 
We don't have similar tests in Pinot Query Handler. As part of this PR, adding Array Column IN filter test.