### PR TITLE
fix: handles default case for string array IN filter for pinot handlers

### DIFF
--- a/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
+++ b/query-service-impl/src/main/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverter.java
@@ -450,7 +450,9 @@ class QueryRequestToPinotSQLConverter {
     String ret = null;
     switch (value.getValueType()) {
       case STRING_ARRAY:
-        ret = buildArrayValue(value.getStringArrayList(), paramsBuilder::addStringParam);
+        List<String> values =
+            value.getStringArrayList().size() > 0 ? value.getStringArrayList() : List.of("null");
+        ret = buildArrayValue(values, paramsBuilder::addStringParam);
         break;
       case BYTES_ARRAY:
         ret = buildArrayValue(value.getBytesArrayList(), paramsBuilder::addByteStringParam);

--- a/query-service-impl/src/test/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverterTest.java
+++ b/query-service-impl/src/test/java/org/hypertrace/core/query/service/pinot/QueryRequestToPinotSQLConverterTest.java
@@ -521,6 +521,31 @@ public class QueryRequestToPinotSQLConverterTest {
   }
 
   @Test
+  public void testSQLiWithStringDefaultArrayFilter() {
+    Builder builder = QueryRequest.newBuilder();
+    builder.addSelection(createColumnExpression("Span.displaySpanName"));
+
+    Filter filter =
+        createInFilter(
+            "Span.displaySpanName", List.of());
+    builder.setFilter(filter);
+
+    ViewDefinition viewDefinition = getDefaultViewDefinition();
+    defaultMockingForExecutionContext();
+
+    assertPQLQuery(
+        builder.build(),
+        "SELECT span_name FROM SpanEventView WHERE "
+            + viewDefinition.getTenantIdColumn()
+            + " = '"
+            + TENANT_ID
+            + "' "
+            + "AND span_name IN ('null')",
+        viewDefinition,
+        executionContext);
+  }
+
+  @Test
   public void testSQLiWithBooleanArrayFilter() {
     Builder builder = QueryRequest.newBuilder();
     builder.addSelection(createColumnExpression("Span.displaySpanName"));


### PR DESCRIPTION
## Description
The default value for string column is `null` in pinot - https://docs.pinot.apache.org/configuration-reference/schema
So, there are cases when query can only returns `null` group. These cases a follow up query with empty clause as shown in the below example:

```
Select dateTimeConvert(start_time_millis,'1:MILLISECONDS:EPOCH','1:MILLISECONDS:EPOCH','300:SECONDS'), span_name, COUNT(*) FROM spanEventView WHERE customer_id = '__default' 
AND start_time_millis >= 1701052800000 AND start_time_millis < 1701138900000 
AND ( user_roles IN ('null') ) ) ) 
GROUP BY dateTimeConvert(start_time_millis,'1:MILLISECONDS:EPOCH','1:MILLISECONDS:EPOCH','300:SECONDS'), user_roles 
limit 1000
```

It could possible that given time limit window, we have only one group `null`. 

This PR, handles the above default scenario.


### Testing
Added Unit test.

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

