### PR TITLE
chore: exclude transitive dependency log4j-slf4j-impl

### DIFF
--- a/query-service-impl/build.gradle.kts
+++ b/query-service-impl/build.gradle.kts
@@ -71,6 +71,7 @@ dependencies {
     // We want to use log4j2 impl so exclude the log4j binding of slf4j
     exclude("org.slf4j", "slf4j-log4j12")
     exclude("log4j", "log4j")
+    exclude("org.apache.logging.log4j", "log4j-slf4j-impl")
   }
   implementation("org.slf4j:slf4j-api:2.0.11")
   implementation("commons-codec:commons-codec:1.15")


### PR DESCRIPTION
fixes:
```
Exception in thread "main" java.lang.NoSuchMethodError: 'void org.apache.logging.slf4j.Log4jLoggerFactory.<init>(org.apache.logging.slf4j.Log4jMarkerFactory)'
	at org.apache.logging.slf4j.SLF4JServiceProvider.initialize(SLF4JServiceProvider.java:57)
	at org.slf4j.LoggerFactory.bind(LoggerFactory.java:196)
	at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:183)
	at org.slf4j.LoggerFactory.getProvider(LoggerFactory.java:486)
	at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:472)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:421)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:447)
	at org.hypertrace.core.serviceframework.PlatformServiceLauncher.<clinit>(PlatformServiceLauncher.java:14)
```